### PR TITLE
refactor(models)!: prefix public exports with Tbx per naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This package provides TypeScript domain model interfaces for the TeqBench application framework. The primary export is `BaseModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
+This package provides TypeScript domain model interfaces for the TeqBench application framework. The primary export is `TbxBaseModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-number.json)
 
-> TypeScript domain model interfaces for the TeqBench application framework. Provides BaseModel contracts consumed by all @teqbench packages.
+> TypeScript domain model interfaces for the TeqBench application framework. Provides TbxBaseModel contracts consumed by all @teqbench packages.
 
 ## Installation
 
@@ -21,22 +21,22 @@ npm install @teqbench/tbx-models
 ## Usage
 
 ```typescript
-import type { BaseModel } from '@teqbench/tbx-models';
+import type { TbxBaseModel } from '@teqbench/tbx-models';
 
-// Extend BaseModel for your domain entities
-interface User extends BaseModel {
+// Extend TbxBaseModel for your domain entities
+interface User extends TbxBaseModel {
     email: string;
 }
 
 // Use a numeric identifier
-interface LegacyRecord extends BaseModel<number> {
+interface LegacyRecord extends TbxBaseModel<number> {
     label: string;
 }
 ```
 
 ## API Reference
 
-### `BaseModel<TId = string>`
+### `TbxBaseModel<TId = string>`
 
 Base interface for all TeqBench domain models. Every persistable entity extends this contract.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teqbench/tbx-models",
   "version": "0.1.0",
-  "description": "TypeScript domain model interfaces for the TeqBench application framework. Provides BaseModel contracts consumed by all @teqbench packages.",
+  "description": "TypeScript domain model interfaces for the TeqBench application framework. Provides TbxBaseModel contracts consumed by all @teqbench packages.",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/src/base-model.spec.ts
+++ b/src/base-model.spec.ts
@@ -1,8 +1,8 @@
-import type { BaseModel } from './base-model';
+import type { TbxBaseModel } from './base-model';
 
-describe('BaseModel', () => {
+describe('TbxBaseModel', () => {
     it('should accept an object with string id by default', () => {
-        const model: BaseModel = {
+        const model: TbxBaseModel = {
             id: 'abc-123',
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-06-15T12:30:00.000Z',
@@ -14,7 +14,7 @@ describe('BaseModel', () => {
     });
 
     it('should accept a numeric id when parameterised with number', () => {
-        const model: BaseModel<number> = {
+        const model: TbxBaseModel<number> = {
             id: 42,
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-06-15T12:30:00.000Z',
@@ -24,7 +24,7 @@ describe('BaseModel', () => {
     });
 
     it('should enforce readonly on all properties', () => {
-        const model: BaseModel = {
+        const model: TbxBaseModel = {
             id: 'readonly-test',
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-01-01T00:00:00.000Z',
@@ -36,7 +36,7 @@ describe('BaseModel', () => {
     });
 
     it('should allow extension with additional properties', () => {
-        interface User extends BaseModel {
+        interface User extends TbxBaseModel {
             email: string;
         }
 

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -12,17 +12,17 @@
  * @example
  * ```typescript
  * // Default string identifier
- * interface User extends BaseModel {
+ * interface User extends TbxBaseModel {
  *     email: string;
  * }
  *
  * // Numeric identifier
- * interface LegacyRecord extends BaseModel<number> {
+ * interface LegacyRecord extends TbxBaseModel<number> {
  *     label: string;
  * }
  * ```
  */
-export interface BaseModel<TId = string> {
+export interface TbxBaseModel<TId = string> {
     /**
      * Unique identifier for the model instance.
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export type { BaseModel } from './base-model';
+export type { TbxBaseModel } from './base-model';


### PR DESCRIPTION
## Summary
- Rename `BaseModel` → `TbxBaseModel` to align with the @teqbench standardized export naming convention (`Tbx` prefix for `tbx-*` packages)
- Updates source, barrel file, tests, and documentation (README, CLAUDE.md, package.json)

**BREAKING CHANGE:** `BaseModel` is now exported as `TbxBaseModel`.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (4/4 tests)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)