### PR TITLE
docs: add external links, TSDoc conventions, and AI friendliness across all docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,11 +26,11 @@ assignees: ''
 
 ## Environment
 
-| Item    | Value |
-| ------- | ----- |
-| Node.js |       |
-| npm     |       |
-| OS      |       |
+| Item                             | Value |
+| -------------------------------- | ----- |
+| [Node.js ↗](https://nodejs.org/) |       |
+| npm                              |       |
+| OS                               |       |
 
 ## Additional Context
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Closes #
 ## Checklist
 
 - [ ] My branch is based on `dev` (or `main` for hotfixes)
-- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+- [ ] Commit messages follow [Conventional Commits ↗](https://www.conventionalcommits.org/)
 - [ ] `npm run format:check` passes
 - [ ] `npm run typecheck` passes
 - [ ] `npm run lint` passes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,38 @@ All exported TypeScript declarations must have TSDoc comments validated by `esli
 - `@related` — Cross-reference to a related export, optionally in another `@teqbench` package (e.g., "TbxAuthService" or "@teqbench/tbx-auth#TbxAuthService"). Repeatable — use one `@related` tag per reference.
 - `@usage` — Prose description of when and why to use this export, distinct from `@example` which shows code. Helps the AI generator produce contextual KB articles rather than raw API listings.
 - `@displayName` — Human-friendly label used as the heading in generated docs (e.g., "Base Model" for `TbxModel`). When omitted, the export name is used as-is.
-- `@order` — Numeric sort hint controlling display sequence within a `@category` on generated pages. Lower numbers appear first. When omitted, exports are sorted alphabetically.
+- `@order` — Numeric sort hint controlling display sequence. Applied at two levels:
+    - Top-level exports: controls display sequence within a `@category` on generated pages.
+    - Members (properties, methods): controls display sequence within the parent class/interface page. Members without `@order` are sorted by precedence group (see Member Ordering below), then alphabetically.
+
+### Member Ordering
+
+The documentation generator groups and sorts members within a class or interface page using the following precedence. Within each group, members are sorted by `@order` (lowest first), then alphabetically.
+
+1. Constructor(s)
+2. Identity properties (named `id` or with `@order` < 10)
+3. Required readonly properties
+4. Required mutable properties
+5. Optional properties
+6. Abstract methods
+7. Public methods
+8. Protected methods
+9. Static members
+10. Events / callbacks
+11. Deprecated members
+
+Add `@order` to any member where alphabetical sorting within its group produces the wrong result. Common cases:
+
+- `id` should appear before `createdAt` and `updatedAt` — give `id` `@order 1`.
+- Lifecycle-related properties should appear in logical sequence — use `@order` to enforce creation-before-update ordering.
 
 ### Comment Structure
 
+Top-level exports:
+
 ````typescript
 /**
- * Summary line — one sentence, no period.
+ * Summary line — one sentence, no period
  *
  * @remarks
  * Extended description. Multiple paragraphs allowed.
@@ -96,6 +121,21 @@ All exported TypeScript declarations must have TSDoc comments validated by `esli
  * @public
  */
 ````
+
+Members (properties, methods):
+
+```typescript
+/**
+ * Summary line — one sentence, no period
+ *
+ * @remarks
+ * Extended description if needed.
+ *
+ * @order 1
+ *
+ * @public
+ */
+```
 
 ## Commit Convention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This package provides TypeScript domain model interfaces for the TeqBench application framework. The primary export is `TbxBaseModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
+This package provides TypeScript domain model interfaces for the TeqBench application framework. The primary export is `TbxModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,27 +4,27 @@ This file provides guidance for Claude Code when working in this repository.
 
 ## Package Overview
 
-This package provides TypeScript domain model interfaces for the TeqBench application framework. The primary export is `TbxModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
+This package provides [TypeScript ↗](https://www.typescriptlang.org) domain model interfaces for the TeqBench application framework. The primary export is `TbxModel<TId>`, a generic interface defining identity and audit timestamp contracts (`id`, `createdAt`, `updatedAt`) consumed by all `@teqbench` packages.
 
 ## Tech Stack
 
-- **Language:** TypeScript 5.9+ (strict mode, ES2022 target, bundler module resolution)
-- **Testing:** Vitest (globals enabled)
-- **Linting:** ESLint flat config with typescript-eslint
-- **Formatting:** Prettier (enforced via pre-commit hook and CI)
-- **Git Hooks:** Husky + lint-staged
-- **Versioning:** Release Please (Conventional Commits)
-- **Registry:** GitHub Packages (`@teqbench` scope)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org) 5.9+ (strict mode, ES2022 target, bundler module resolution)
+- **Testing:** [Vitest ↗](https://vitest.dev) (globals enabled)
+- **Linting:** [ESLint ↗](https://eslint.org) flat config with [typescript-eslint ↗](https://typescript-eslint.io)
+- **Formatting:** [Prettier ↗](https://prettier.io) (enforced via pre-commit hook and CI)
+- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/lint-staged/lint-staged)
+- **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://www.conventionalcommits.org))
+- **Registry:** [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) (`@teqbench` scope)
 
 ## Key Commands
 
 - `npm ci` — Install dependencies (use this, not `npm install`)
-- `npm run build` — Compile TypeScript to `dist/`
-- `npm test` — Run tests with Vitest
+- `npm run build` — Compile [TypeScript ↗](https://www.typescriptlang.org) to `dist/`
+- `npm test` — Run tests with [Vitest ↗](https://vitest.dev)
 - `npm run test:coverage` — Run tests with coverage enforcement (used in CI)
-- `npm run typecheck` — Full TypeScript type-check (`tsc --noEmit`)
-- `npm run lint` — Run ESLint
-- `npm run format` — Format all files with Prettier
+- `npm run typecheck` — Full [TypeScript ↗](https://www.typescriptlang.org) type-check (`tsc --noEmit`)
+- `npm run lint` — Run [ESLint ↗](https://eslint.org)
+- `npm run format` — Format all files with [Prettier ↗](https://prettier.io)
 - `npm run format:check` — Check formatting (CI mode)
 
 ## Project Structure
@@ -38,23 +38,23 @@ This package provides TypeScript domain model interfaces for the TeqBench applic
 
 ## Publishing
 
-- Packages are published to GitHub Packages (`@teqbench` scope) via the release workflow.
-- Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
-- **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`fesm2022/`, etc.). The release workflow publishes from `dist/` directly (`npm publish ./dist`), so consumers resolve against ng-packagr's generated `package.json`. The root `package.json` does not need `main`, `types`, or `exports` fields.
+- Packages are published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) (`@teqbench` scope) via the release workflow.
+- Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file. Lines guarded by `/* v8 ignore next */` are excluded from [V8 ↗](https://v8.dev) coverage collection (used by [Vitest ↗](https://vitest.dev)). This pragma marks code that is unreachable in the test environment (e.g., SSR `window` guards).
+- **Build tooling:** [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) is used to build [Angular ↗](https://angular.dev) Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) generates its own `package.json` inside `dist/` with the correct APF entry points (`fesm2022/`, etc.). The release workflow publishes from `dist/` directly (`npm publish ./dist`), so consumers resolve against [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr)'s generated `package.json`. The root `package.json` does not need `main`, `types`, or `exports` fields.
 
 ## TSDoc Convention
 
-All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by API Extractor and the AI HTML documentation generator.
+All exported [TypeScript ↗](https://www.typescriptlang.org) declarations must have [TSDoc ↗](https://tsdoc.org) comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by [API Extractor ↗](https://api-extractor.com) and the AI HTML documentation generator.
 
 ### Standard Tags (always use)
 
 - `@remarks` — Extended description, separated from the summary line.
 - `@typeParam` — Document generic type parameters (not `@template`).
 - `@param` — Document function/method parameters.
-- `@returns` — Document return values.
-- `@example` — Code examples in fenced TypeScript blocks.
-- `@packageDocumentation` — Required on every barrel file (`index.ts`) to describe the package entry point. Use `{@link ExportName}` to cross-reference primary exports.
+- `@returns` — Document return values. Omit for `void` returns.
+- `@example` — Code examples in fenced [TypeScript ↗](https://www.typescriptlang.org) blocks.
 - `@public` / `@internal` — Release tag on every export. Use `@public` unless the export is not part of the package API surface.
+- `@packageDocumentation` — Required on every barrel file (`index.ts`) to describe the package entry point. Use `{@link ExportName}` to cross-reference primary exports.
 - `@see` — Reference to related external resources or docs.
 - `@deprecated` — Mark deprecated APIs with migration guidance.
 
@@ -74,7 +74,7 @@ All exported TypeScript declarations must have TSDoc comments validated by `esli
 The documentation generator groups and sorts members within a class or interface page using the following precedence. Within each group, members are sorted by `@order` (lowest first), then alphabetically.
 
 1. Constructor(s)
-2. Identity properties (named `id` or with `@order` < 10)
+2. Identity properties (named `id`)
 3. Required readonly properties
 4. Required mutable properties
 5. Optional properties
@@ -122,7 +122,7 @@ Top-level exports:
  */
 ````
 
-Members (properties, methods):
+Member-level comment structure (properties, methods):
 
 ```typescript
 /**
@@ -137,9 +137,107 @@ Members (properties, methods):
  */
 ```
 
+### Tag Ordering
+
+Follow this order within a [TSDoc ↗](https://tsdoc.org) comment:
+
+Top-level exports:
+
+summary line
+@remarks
+@typeParam / @param / @returns
+@usage
+@example
+@category (repeatable)
+@displayName
+@order
+@since
+@related (repeatable)
+@public / @internal
+
+Members (properties, methods):
+
+summary line
+@remarks
+@param / @returns (methods only)
+@order
+@public / @internal
+
+### Reference Implementation
+
+`@teqbench/tbx-models` `src/base-model.ts` is the reference for a fully migrated [TSDoc ↗](https://tsdoc.org) comment on an interface with member-level docs including `@order` tags. `src/index.ts` in this same package is the reference for a `@packageDocumentation` barrel file [TSDoc ↗](https://tsdoc.org) comment.
+
+### Verification
+
+After migration, run `npm run lint` and confirm no `tsdoc/syntax` warnings. Run `npm run format:check` and `npm test` to ensure nothing broke.
+
+## External Linking Convention
+
+Every prose mention of an external specification, standard, or technology in documentation must be hyperlinked to its official source. This applies to all markdown files (.md) and all [TSDoc ↗](https://tsdoc.org) comments in [TypeScript ↗](https://www.typescriptlang.org) source files (.ts). Exclude CHANGELOG.md, git submodules, and build output directories.
+
+### Format
+
+- **Markdown:** `[Name ↗](url)` with the ↗ (U+2197) character inside the link text for external resources. Internal/relative links do not use ↗.
+- **TSDoc:** `{@link url | Name}` inline syntax in every section where an external technology appears — summary, `@remarks`, `@usage`, `@param`, `@returns`, and member-level docs. For each distinct external resource referenced in a top-level export's summary, add a `@see {@link url | Name}` tag in the tag section.
+
+### Rules
+
+- Link to the official specification or project homepage, not Wikipedia or third-party summaries.
+- Use canonical names (e.g., "ISO 8601" not "ISO-8601").
+- Internal references and cross-references to other `@teqbench` packages use relative links or `{@link ExportName}` without ↗.
+- Link every prose mention, not just the first occurrence per document.
+- Do not place links inside backtick code spans or section headings.
+- License references link to the project's own LICENSE file using a relative path, without ↗.
+- [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) links use the org packages page, not the generic feature page.
+- Project-specific service instances (badge gist, org packages page, issue templates) link to the actual instance URL, not the generic service homepage. Discover URLs from README badge URLs, workflow files, `package.json`, and config files.
+
+### SECURITY.md Reporting Channel
+
+- **Private repository:** Email link (`[info@teqbench.dev](mailto:info@teqbench.dev)`). GitHub Private vulnerability reporting is not available without GitHub Advanced Security.
+- **Public repository:** [GitHub Private vulnerability reporting ↗](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) via `/security/advisories/new`. Enable at the org level if available, otherwise at the repo level.
+- When transitioning a repo from private to public, update SECURITY.md to switch from email to the advisory URL.
+
+### README Requirements
+
+The README must have a "Feedback" section immediately above "License" with links to Bug Report and Feature Request issue templates using the `issues/new?template=` URL pattern.
+
+## AI Friendliness Convention
+
+All [TSDoc ↗](https://tsdoc.org) comments, inline code comments, and markdown files must be written for AI consumption — documentation generators, code assistants, and retrieval-augmented generation systems parse these to answer questions, generate docs, or suggest code.
+
+### Disambiguation
+
+- Every `{@link ExportName}` must resolve to an export in the current package. References to external types must include a full URL: `{@link https://angular.dev/api/core/ClassName | ClassName}`.
+- Barrel file grouping comments (e.g., `// Models`, `// Services`) must match the `@category` tags on the exports they group.
+- `@category Interface` is reserved for [TypeScript ↗](https://www.typescriptlang.org) `interface` declarations. Abstract classes serving as DI tokens or extension points use `@category Contract`.
+
+### Context Completeness
+
+- Do not imply auto-registration. If consumers must explicitly provide an implementation via DI, say so. Do not write "default implementation" without clarifying that no provider is registered automatically.
+- Optional fields the pipeline never populates must state that explicitly (e.g., "the pipeline never sets this field; set it when constructing a context manually").
+- Methods with error-handling behavior (try/catch, swallowing, fallback) must document it in `@remarks`.
+- Hypothetical class names in `@example` blocks must include a comment identifying them as consumer-defined placeholders (e.g., `// SentryErrorLogger is a hypothetical consumer-defined subclass`).
+- References to files or configurations in other repositories must note they are external and not accessible from the current repo.
+
+### Structural Consistency
+
+- Every exported class and function must have an `@example` tag.
+- Do not duplicate the same URL in both an inline `{@link}` and a `@see` tag on the same member.
+- `@internal` members must have a summary line before the tag.
+- `@returns` is required for non-void returns; omit for `void`.
+- Summary lines must lead with the primary action matching the export name (e.g., `logClientError` summarizes as "Log a manually caught error..." not "Build a structured error context...").
+
+### Semantic Clarity
+
+- Do not use terms with established technical meanings in unintended ways (e.g., "side-effect pattern" for fan-out, "structured output" for human-readable console logging).
+- Do not reference concepts or patterns that do not exist in the codebase.
+- Coverage pragmas (`/* v8 ignore next */`) and other non-obvious annotations must be documented in this file (see Publishing section).
+- Configuration snapshots in documentation must note they are examples that may not reflect the current state.
+- Custom `package.json` metadata fields (not defined by the [npm ↗](https://www.npmjs.com) spec) must be identified as custom where referenced.
+
 ## Commit Convention
 
-Follow **Conventional Commits** strictly:
+Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) strictly:
 
 - `feat(scope): ...` — New feature (minor bump)
 - `fix(scope): ...` — Bug fix (patch bump)
@@ -160,7 +258,7 @@ Follow **Conventional Commits** strictly:
 
 - Create feature or bugfix branches off `dev` when implementing issues.
 - Write clean, well-tested code that passes lint, typecheck, and tests.
-- Use conventional commit messages.
+- Use [Conventional Commits ↗](https://www.conventionalcommits.org) messages.
 - Create PRs targeting `dev` (never directly target `main`).
 - Keep PRs focused and atomic — one issue per PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,61 @@ This package provides TypeScript domain model interfaces for the TeqBench applic
 - Coverage thresholds are enforced in CI: 80% lines/functions/statements, 75% branches, per file.
 - **Build tooling:** ng-packagr is used to build Angular Package Format (APF) output. It uses bundler module resolution internally, so source files use extensionless relative imports (e.g., `'./foo.service'`). The `ng-package.json` at the repo root configures the entry point and output directory. ng-packagr generates its own `package.json` inside `dist/` with the correct APF entry points (`fesm2022/`, etc.). The release workflow publishes from `dist/` directly (`npm publish ./dist`), so consumers resolve against ng-packagr's generated `package.json`. The root `package.json` does not need `main`, `types`, or `exports` fields.
 
+## TSDoc Convention
+
+All exported TypeScript declarations must have TSDoc comments validated by `eslint-plugin-tsdoc`. Custom tags are defined in `tsdoc.json` and consumed downstream by API Extractor and the AI HTML documentation generator.
+
+### Standard Tags (always use)
+
+- `@remarks` — Extended description, separated from the summary line.
+- `@typeParam` — Document generic type parameters (not `@template`).
+- `@param` — Document function/method parameters.
+- `@returns` — Document return values.
+- `@example` — Code examples in fenced TypeScript blocks.
+- `@packageDocumentation` — Required on every barrel file (`index.ts`) to describe the package entry point. Use `{@link ExportName}` to cross-reference primary exports.
+- `@public` / `@internal` — Release tag on every export. Use `@public` unless the export is not part of the package API surface.
+- `@see` — Reference to related external resources or docs.
+- `@deprecated` — Mark deprecated APIs with migration guidance.
+
+### Custom Tags
+
+- `@category` — Group exports by domain for navigation and table-of-contents generation (e.g., "Models", "Services", "Utilities", "Pipes", "Guards"). Repeatable — an export can belong to multiple categories (e.g., "Models", "Foundational", "Interface").
+- `@since` — The package version when the export was first introduced (e.g., "1.0.0"). Allows the docs generator to render version badges and filter by release.
+- `@related` — Cross-reference to a related export, optionally in another `@teqbench` package (e.g., "TbxAuthService" or "@teqbench/tbx-auth#TbxAuthService"). Repeatable — use one `@related` tag per reference.
+- `@usage` — Prose description of when and why to use this export, distinct from `@example` which shows code. Helps the AI generator produce contextual KB articles rather than raw API listings.
+- `@displayName` — Human-friendly label used as the heading in generated docs (e.g., "Base Model" for `TbxModel`). When omitted, the export name is used as-is.
+- `@order` — Numeric sort hint controlling display sequence within a `@category` on generated pages. Lower numbers appear first. When omitted, exports are sorted alphabetically.
+
+### Comment Structure
+
+````typescript
+/**
+ * Summary line — one sentence, no period.
+ *
+ * @remarks
+ * Extended description. Multiple paragraphs allowed.
+ *
+ * @typeParam T - Description of the generic parameter.
+ *
+ * @usage
+ * When and why to use this export.
+ *
+ * @example
+ * ```typescript
+ * // usage example
+ * ```
+ *
+ * @category Models
+ * @category Foundational
+ * @displayName Base Model
+ * @order 1
+ * @since 1.0.0
+ * @related OtherExport
+ *
+ * @public
+ */
+````
+
 ## Commit Convention
 
 Follow **Conventional Commits** strictly:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -115,16 +115,16 @@ community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct is adapted from the [Contributor Covenant ↗][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html ↗][v2.1].
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+[Mozilla's code of conduct enforcement ladder ↗][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+[https://www.contributor-covenant.org/faq ↗][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations ↗][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node.js
 
-Install the version specified in `.nvmrc` (Node 24+). If you use nvm:
+Install the version specified in `.nvmrc` ([Node.js ↗](https://nodejs.org/) 24+). If you use [nvm ↗](https://github.com/nvm-sh/nvm):
 
 ```bash
 nvm install
@@ -13,7 +13,7 @@ nvm use
 
 ### GitHub Packages Authentication
 
-This package depends on `@teqbench` scoped packages hosted on GitHub Packages. To install them locally, you need a GitHub personal access token (PAT) with `read:packages` scope.
+This package depends on `@teqbench` scoped packages hosted on [GitHub Packages ↗](https://github.com/orgs/teqbench/packages). To install them locally, you need a GitHub personal access token (PAT) with `read:packages` scope.
 
 1. Create a PAT at **GitHub > Settings > Developer settings > Personal access tokens** with `read:packages` scope
 2. Add it to your shell profile (`~/.zshrc` or `~/.bashrc`):
@@ -26,20 +26,20 @@ This package depends on `@teqbench` scoped packages hosted on GitHub Packages. T
     ```
 4. Open a new terminal (or `source ~/.zshrc`) and verify: `npm ci`
 
-The repo `.npmrc` already configures the `@teqbench` scope to use GitHub Packages. The `~/.npmrc` auth line tells npm how to authenticate. CI handles this separately via `actions/setup-node`.
+The repo `.npmrc` already configures the `@teqbench` scope to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages). The `~/.npmrc` auth line tells [npm ↗](https://www.npmjs.com/) how to authenticate. CI handles this separately via `actions/setup-node`.
 
 #### Cross-repo package access (CI)
 
-If this package depends on other `@teqbench` packages, each package in the entire dependency tree (direct and transitive) must grant this repository read access on GitHub. For each `@teqbench` package, go to **github.com/orgs/teqbench/packages/npm/\<package-name\>/settings → Manage access**, add this repository, and set the role to **Read**. GitHub Packages has its own access control layer — repository and app permissions alone are not sufficient. Without this, CI will fail with `403 Forbidden` during `npm ci`. For example, if this package depends on `tbx-mat-severity-icons` which depends on `tbx-mat-icons`, you must grant read access on both packages.
+If this package depends on other `@teqbench` packages, each package in the entire dependency tree (direct and transitive) must grant this repository read access on GitHub. For each `@teqbench` package, go to **github.com/orgs/teqbench/packages/npm/\<package-name\>/settings → Manage access**, add this repository, and set the role to **Read**. [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) has its own access control layer — repository and app permissions alone are not sufficient. Without this, CI will fail with `403 Forbidden` during `npm ci`. For example, if this package depends on `tbx-mat-severity-icons` which depends on `tbx-mat-icons`, you must grant read access on both packages.
 
 ## Tech Stack
 
-- **Language:** [TypeScript](https://www.typescriptlang.org) 5.9+
-- **Testing:** [Vitest](https://vitest.dev)
-- **Linting:** [ESLint](https://eslint.org) (Flat Config)
-- **Formatting:** [Prettier](https://prettier.io) (enforced via pre-commit hook and CI)
-- **Git Hooks:** Husky + lint-staged (runs Prettier on staged files before every commit)
-- **Versioning:** [Release Please](https://github.com/googleapis/release-please) (Conventional Commits)
+- **Language:** [TypeScript ↗](https://www.typescriptlang.org/) 5.9+
+- **Testing:** [Vitest ↗](https://vitest.dev/)
+- **Linting:** [ESLint ↗](https://eslint.org/) (Flat Config)
+- **Formatting:** [Prettier ↗](https://prettier.io/) (enforced via pre-commit hook and CI)
+- **Git Hooks:** [Husky ↗](https://typicode.github.io/husky/) + [lint-staged ↗](https://github.com/lint-staged/lint-staged) (runs [Prettier ↗](https://prettier.io/) on staged files before every commit)
+- **Versioning:** [Release Please ↗](https://github.com/googleapis/release-please) ([Conventional Commits ↗](https://www.conventionalcommits.org/))
 
 ## Key Commands
 
@@ -47,14 +47,14 @@ If this package depends on other `@teqbench` packages, each package in the entir
 - `npm run build` — Build the package
 - `npm test` — Run tests
 - `npm run test:coverage` — Run tests with coverage enforcement
-- `npm run typecheck` — Full TypeScript type-check
-- `npm run lint` — Run ESLint checks
-- `npm run format` — Format all files with Prettier
+- `npm run typecheck` — Full [TypeScript ↗](https://www.typescriptlang.org/) type-check
+- `npm run lint` — Run [ESLint ↗](https://eslint.org/) checks
+- `npm run format` — Format all files with [Prettier ↗](https://prettier.io/)
 - `npm run format:check` — Check formatting without writing (used in CI)
 
 ## Commit Convention
 
-Follow **[Conventional Commits](https://www.conventionalcommits.org)** strictly. Release Please uses these to determine version bumps.
+Follow **[Conventional Commits ↗](https://www.conventionalcommits.org/)** strictly. [Release Please ↗](https://github.com/googleapis/release-please) uses these to determine version bumps.
 
 - `feat(scope): ...` — New feature (minor version bump)
 - `fix(scope): ...` — Bug fix (patch version bump)
@@ -96,8 +96,8 @@ Follow **[Conventional Commits](https://www.conventionalcommits.org)** strictly.
 1. Create a `release/*` branch from `dev`
 2. Merge `main` into the release branch to resolve any conflicts (especially badge files)
 3. Open a PR from the release branch to `main`
-4. After merge, Release Please opens a version bump PR on `main`
-5. Merge the Release Please PR to trigger a GitHub Release and publish to GitHub Packages
+4. After merge, [Release Please ↗](https://github.com/googleapis/release-please) opens a version bump PR on `main`
+5. Merge the [Release Please ↗](https://github.com/googleapis/release-please) PR to trigger a GitHub Release and publish to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages)
 6. The sync workflow automatically merges `main` back into `dev`
 
 For details on how the CI/CD pipelines work, see [docs/reference/workflows/](docs/reference/workflows/).

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Base interface for all TeqBench domain models. Every persistable entity extends 
 | Property    | Type     | Description                              |
 | ----------- | -------- | ---------------------------------------- |
 | `id`        | `TId`    | Unique identifier (defaults to `string`) |
-| `createdAt` | `string` | ISO-8601 timestamp of record creation    |
-| `updatedAt` | `string` | ISO-8601 timestamp of last record update |
+| `createdAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of record creation    |
+| `updatedAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of last record update |
 
 ## Compatibility
 
 | Dependency | Version  |
 | ---------- | -------- |
-| TypeScript | ~5.9.0   |
-| Node.js    | >=24.0.0 |
+| [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
+| [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ interface LegacyRecord extends TbxModel<number> {
 
 Base interface for all TeqBench domain models. Every persistable entity extends this contract.
 
-| Property    | Type     | Description                              |
-| ----------- | -------- | ---------------------------------------- |
-| `id`        | `TId`    | Unique identifier (defaults to `string`) |
+| Property    | Type     | Description                                                                                          |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `id`        | `TId`    | Unique identifier (defaults to `string`)                                                             |
 | `createdAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of record creation    |
 | `updatedAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of last record update |
 
 ## Compatibility
 
-| Dependency | Version  |
-| ---------- | -------- |
+| Dependency                                      | Version  |
+| ----------------------------------------------- | -------- |
 | [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
 | [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-number.json)
 
-> TypeScript domain model interfaces for the TeqBench application framework. Provides TbxBaseModel contracts consumed by all @teqbench packages.
+> TypeScript domain model interfaces for the TeqBench application framework. Provides TbxModel contracts consumed by all @teqbench packages.
 
 ## Installation
 
@@ -21,22 +21,22 @@ npm install @teqbench/tbx-models
 ## Usage
 
 ```typescript
-import type { TbxBaseModel } from '@teqbench/tbx-models';
+import type { TbxModel } from '@teqbench/tbx-models';
 
-// Extend TbxBaseModel for your domain entities
-interface User extends TbxBaseModel {
+// Extend TbxModel for your domain entities
+interface User extends TbxModel {
     email: string;
 }
 
 // Use a numeric identifier
-interface LegacyRecord extends TbxBaseModel<number> {
+interface LegacyRecord extends TbxModel<number> {
     label: string;
 }
 ```
 
 ## API Reference
 
-### `TbxBaseModel<TId = string>`
+### `TbxModel<TId = string>`
 
 Base interface for all TeqBench domain models. Every persistable entity extends this contract.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-number.json)
 
-> TypeScript domain model interfaces for the TeqBench application framework. Provides TbxModel contracts consumed by all @teqbench packages.
+> [TypeScript ↗](https://www.typescriptlang.org/) domain model interfaces for the TeqBench application framework. Provides TbxModel contracts consumed by all @teqbench packages.
 
 ## Installation
 
-Configure npm to use GitHub Packages for the `@teqbench` scope:
+Configure [npm ↗](https://www.npmjs.com/) to use [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) for the `@teqbench` scope:
 
 ```bash
 echo "@teqbench:registry=https://npm.pkg.github.com" >> .npmrc

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Base interface for all TeqBench domain models. Every persistable entity extends 
 | [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
 | [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
 
+## Feedback
+
+- [Report a bug ↗](https://github.com/teqbench/tbx-models/issues/new?template=bug_report.md)
+- [Request a feature ↗](https://github.com/teqbench/tbx-models/issues/new?template=feature_request.md)
+
 ## License
 
 [Apache-2.0](LICENSE) — Copyright 2025 TeqBench

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest version on `main` is the only supported version.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-To report a vulnerability, open a [GitHub Security Advisory](https://github.com/teqbench/tbx-models/security/advisories/new) via the **Security** tab of this repository. This keeps the report private until a fix is available.
+To report a vulnerability, open a [GitHub Security Advisory ↗](https://github.com/teqbench/tbx-models/security/advisories/new) via the **Security** tab of this repository. This keeps the report private until a fix is available.
 
 Include as much of the following as possible:
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared GitHub Gist and updates the README with branch-specific Shields.io badge URLs.
+The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared [GitHub Gist ↗](https://gist.github.com/) and updates the README with branch-specific [Shields.io ↗](https://shields.io) badge URLs.
 
 ---
 
@@ -77,7 +77,7 @@ PRs to `main` must come from `release/*`, `hotfix/*`, or `release-please--*` bra
 
 Uses `actions/create-github-app-token@v3` to create a short-lived token from the `teqbench-automation` GitHub App.
 
-This step is conditioned on `github.actor != 'dependabot[bot]'` and is **skipped entirely** on Dependabot PRs. The app secrets are intentionally unavailable to Dependabot — GitHub isolates Dependabot from repository secrets as a security boundary.
+This step is conditioned on `github.actor != 'dependabot[bot]'` and is **skipped entirely** on [Dependabot ↗](https://github.com/dependabot) PRs. The app secrets are intentionally unavailable to [Dependabot ↗](https://github.com/dependabot) — GitHub isolates [Dependabot ↗](https://github.com/dependabot) from repository secrets as a security boundary.
 
 #### 3. Checkout Code
 
@@ -89,7 +89,7 @@ with:
     fetch-depth: 0
 ```
 
-Uses the app token when available. Falls back to `GITHUB_TOKEN` for Dependabot PRs. Submodules (Claude Code skills) are checked out for non-Dependabot runs. `fetch-depth: 0` fetches full history.
+Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://github.com/dependabot) PRs. Submodules (Claude Code skills) are checked out for non-[Dependabot ↗](https://github.com/dependabot) runs. `fetch-depth: 0` fetches full history.
 
 #### 4. Setup Node
 
@@ -119,7 +119,7 @@ Fails the build on high or critical severity vulnerabilities. Runs immediately a
 npm run format:check
 ```
 
-Runs `prettier --check .` against all tracked files. Also enforced locally via the Husky `pre-commit` hook — the CI step is the safety net.
+Runs `prettier --check .` against all tracked files. Also enforced locally via the [Husky ↗](https://typicode.github.io/husky/) `pre-commit` hook — the CI step is the safety net.
 
 #### 8. TypeScript Check
 
@@ -135,7 +135,7 @@ Full type-check (`tsc --noEmit`) without emitting output.
 npm run lint
 ```
 
-Runs ESLint with the flat config (`eslint.config.js`).
+Runs [ESLint ↗](https://eslint.org) with the flat config (`eslint.config.js`).
 
 #### 10. Run Tests with Coverage
 
@@ -159,7 +159,7 @@ Extracts badge data from test output for the gist push steps:
 
 #### 12. Check README Version Drift
 
-Compares the TypeScript and Node.js versions in `README.md`'s compatibility table against `package.json`. Fails the build if they don't match, preventing documentation drift after dependency updates.
+Compares the [TypeScript ↗](https://www.typescriptlang.org/) and [Node.js ↗](https://nodejs.org/) versions in `README.md`'s compatibility table against `package.json`. Fails the build if they don't match, preventing documentation drift after dependency updates.
 
 #### 13. Build
 
@@ -167,11 +167,11 @@ Compares the TypeScript and Node.js versions in `README.md`'s compatibility tabl
 npm run build
 ```
 
-Compiles TypeScript to `dist/` using `tsconfig.build.json`.
+Compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/` using `tsconfig.build.json`.
 
 #### 14–18. Push Badge Data to Gist
 
-Five badges are pushed as JSON to a shared public GitHub Gist using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
+Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
 
 | Badge        | Style         | Source                                            | Gist Filename                       |
 | ------------ | ------------- | ------------------------------------------------- | ----------------------------------- |
@@ -214,4 +214,4 @@ The gist stores JSON files matching the [Shields.io endpoint schema](https://shi
 }
 ```
 
-Shields.io caches responses for ~5 minutes. After a CI run, badges may take a few minutes to reflect new data.
+[Shields.io ↗](https://shields.io) caches responses for ~5 minutes. After a CI run, badges may take a few minutes to reflect new data.

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -93,7 +93,7 @@ Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot 
 
 #### 4. Setup Node
 
-Reads the Node version from `.nvmrc` with npm cache enabled.
+Reads the [Node.js ↗](https://nodejs.org/) version from `.nvmrc` with [npm ↗](https://www.npmjs.com/) cache enabled.
 
 #### 5. Install Dependencies
 
@@ -101,9 +101,9 @@ Reads the Node version from `.nvmrc` with npm cache enabled.
 npm ci
 ```
 
-Clean install from `package-lock.json` for deterministic builds. `GITHUB_TOKEN` is used with `packages: read` permission (inherited from the job's `contents: read` scope) to authenticate with GitHub Packages.
+Clean install from `package-lock.json` for deterministic builds. `GITHUB_TOKEN` is used with `packages: read` permission (inherited from the job's `contents: read` scope) to authenticate with [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 
-> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**GitHub Packages → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies. Without this, `npm ci` will fail with `403 Forbidden`.
+> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies. Without this, `npm ci` will fail with `403 Forbidden`.
 
 #### 6. Audit Dependencies
 
@@ -171,7 +171,7 @@ Compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/` using `tsc
 
 #### 14–18. Push Badge Data to Gist
 
-Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
+Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io ↗](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
 
 | Badge        | Style         | Source                                            | Gist Filename                       |
 | ------------ | ------------- | ------------------------------------------------- | ----------------------------------- |
@@ -196,13 +196,13 @@ All badge steps run with `if: always()` so badges update even on failure. The `s
 
 ## Badge Rendering
 
-Badges are rendered by [Shields.io endpoint badges](https://shields.io/badges/endpoint-badge). The URL format is:
+Badges are rendered by [Shields.io endpoint badges ↗](https://shields.io/badges/endpoint-badge). The URL format is:
 
 ```
 https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/{GIST_OWNER}/{GIST_ID}/raw/{REPO_NAME}-{BRANCH}-{badge}.json
 ```
 
-The gist stores JSON files matching the [Shields.io endpoint schema](https://shields.io/badges/endpoint-badge):
+The gist stores JSON files matching the [Shields.io endpoint schema ↗](https://shields.io/badges/endpoint-badge):
 
 ```json
 {

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared [GitHub Gist ↗](https://gist.github.com/) and updates the README with branch-specific [Shields.io ↗](https://shields.io) badge URLs.
+The CI workflow is the quality gate for the repository. It runs formatting checks, type checking, linting, tests with coverage enforcement, dependency auditing, and README version drift detection on every push and pull request to `main` and `dev`. After a successful push (not PR), it pushes badge data to a shared [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) and updates the README with branch-specific [Shields.io ↗](https://shields.io) badge URLs.
 
 ---
 
@@ -171,7 +171,7 @@ Compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/` using `tsc
 
 #### 14–18. Push Badge Data to Gist
 
-Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
+Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
 
 | Badge        | Style         | Source                                            | Gist Filename                       |
 | ------------ | ------------- | ------------------------------------------------- | ----------------------------------- |

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -20,8 +20,6 @@ The CI workflow is the quality gate for the repository. It runs formatting check
 
 ---
 
----
-
 ## Concurrency
 
 ```yaml

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -89,7 +89,7 @@ with:
     fetch-depth: 0
 ```
 
-Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://github.com/dependabot) PRs. Submodules (Claude Code skills) are checked out for non-[Dependabot ↗](https://github.com/dependabot) runs. `fetch-depth: 0` fetches full history.
+Uses the app token when available. Falls back to `GITHUB_TOKEN` for [Dependabot ↗](https://github.com/dependabot) PRs. Submodules ([Claude Code ↗](https://github.com/anthropics/claude-code) skills) are checked out for non-[Dependabot ↗](https://github.com/dependabot) runs. `fetch-depth: 0` fetches full history.
 
 #### 4. Setup Node
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -1,6 +1,6 @@
 # Claude Code Workflow — `claude.yml`
 
-**Full name:** TeqBench Package - Claude Code Workflow
+**Full name:** TeqBench Package - [Claude Code ↗](https://github.com/anthropics/claude-code) Workflow
 **File:** `.github/workflows/claude.yml`
 
 ---

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -204,4 +204,4 @@ Claude will:
 - **Max turns:** 10 — prevents runaway sessions
 - **Timeout:** 30 minutes — hard cap on execution time
 - **No workflow edits** — Claude should not modify `.github/workflows/*` without explicit instruction (enforced by `CLAUDE.md` conventions)
-- **No release file edits** — Claude should not modify `release-please-config.json`, `.release-please-manifest.json`, `CHANGELOG.md`, or `.badges/*` (enforced by `CLAUDE.md` conventions)
+- **No release file edits** — Claude should not modify `release-please-config.json`, `.release-please-manifest.json`, or `CHANGELOG.md` (enforced by `CLAUDE.md` conventions)

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The Claude Code workflow provides AI-powered assistance directly in GitHub issues and pull requests. When a user mentions `@claude` in a comment or issue body, Claude reads the codebase, analyzes the request, and can implement features, fix bugs, review code, or create pull requests — all within the GitHub UI.
+The [Claude Code ↗](https://github.com/anthropics/claude-code) workflow provides AI-powered assistance directly in GitHub issues and pull requests. When a user mentions `@claude` in a comment or issue body, Claude reads the codebase, analyzes the request, and can implement features, fix bugs, review code, or create pull requests — all within the GitHub UI.
 
 ---
 
@@ -50,13 +50,13 @@ jobs:
 
 ## Secrets Used
 
-| Secret              | Purpose                                  |
-| ------------------- | ---------------------------------------- |
-| `APP_ID`            | GitHub App ID for generating a bot token |
-| `APP_PRIVATE_KEY`   | GitHub App private key                   |
-| `ANTHROPIC_API_KEY` | Authenticates with the Anthropic API     |
+| Secret              | Purpose                                                               |
+| ------------------- | --------------------------------------------------------------------- |
+| `APP_ID`            | GitHub App ID for generating a bot token                              |
+| `APP_PRIVATE_KEY`   | GitHub App private key                                                |
+| `ANTHROPIC_API_KEY` | Authenticates with the [Anthropic API ↗](https://docs.anthropic.com/) |
 
-The app token is used for checkout with submodules (Claude Code skills) and for full repository access.
+The app token is used for checkout with submodules ([Claude Code ↗](https://github.com/anthropics/claude-code) skills) and for full repository access.
 
 ---
 
@@ -173,7 +173,7 @@ Claude reads the `CLAUDE.md` file in the repo root for project-specific context.
 - Branching rules and workflow expectations
 - Explicit do's and don'ts for Claude's behavior
 
-Both the GitHub Action and the Claude Code CLI read the same `CLAUDE.md`, ensuring consistent behavior across local and CI environments.
+Both the GitHub Action and the [Claude Code ↗](https://github.com/anthropics/claude-code) CLI read the same `CLAUDE.md`, ensuring consistent behavior across local and CI environments.
 
 ---
 
@@ -194,7 +194,7 @@ Claude will:
 2. Create a feature or bugfix branch off `dev`
 3. Implement the requested changes
 4. Run tests and lint to verify
-5. Commit with conventional commit messages
+5. Commit with [Conventional Commits ↗](https://www.conventionalcommits.org/) messages
 6. Push and create a PR targeting `dev`
 
 ---

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -158,7 +158,7 @@ Claude's capabilities are explicitly restricted via `--allowedTools` to prevent 
 | --------- | --------------------------------------- |
 | `npm run` | Run project scripts (test, lint, build) |
 | `npm ci`  | Install dependencies                    |
-| `npx`     | Run Node.js binaries                    |
+| `npx`     | Run [Node.js ↗](https://nodejs.org/) binaries                    |
 
 ---
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -154,11 +154,11 @@ Claude's capabilities are explicitly restricted via `--allowedTools` to prevent 
 
 ### npm Commands (Via Bash Allowlist)
 
-| Allowed   | Purpose                                 |
-| --------- | --------------------------------------- |
-| `npm run` | Run project scripts (test, lint, build) |
-| `npm ci`  | Install dependencies                    |
-| `npx`     | Run [Node.js ↗](https://nodejs.org/) binaries                    |
+| Allowed   | Purpose                                       |
+| --------- | --------------------------------------------- |
+| `npm run` | Run project scripts (test, lint, build)       |
+| `npm ci`  | Install dependencies                          |
+| `npx`     | Run [Node.js ↗](https://nodejs.org/) binaries |
 
 ---
 

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-Tracks pinned dependencies that are waiting for a new version — for example, waiting for a package to release a compatible major version before it can be adopted. The workflow checks the npm registry daily, evaluates resolution conditions, and posts status updates to a tracking issue.
+Tracks pinned dependencies that are waiting for a new version — for example, waiting for a package to release a compatible major version before it can be adopted. The workflow checks the [npm ↗](https://www.npmjs.com/) registry daily, evaluates resolution conditions, and posts status updates to a tracking issue.
 
 ---
 

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -37,7 +37,7 @@ Only needs write access to issues for posting status comments.
 | -------------- | --------------------------- |
 | `GITHUB_TOKEN` | Default token for API calls |
 
-No app token needed — this workflow only reads the npm registry and writes issue comments.
+No app token needed — this workflow only reads the [npm ↗](https://www.npmjs.com/) registry and writes issue comments.
 
 ---
 
@@ -78,7 +78,7 @@ also-track: @angular/cli, @angular/compiler
 ### Evaluation Flow
 
 1. Finds open issues with `Part of #<EPIC>` and `<!-- dep-compat ... -->` metadata.
-2. For each, queries the npm registry for the latest version.
+2. For each, queries the [npm ↗](https://www.npmjs.com/) registry for the latest version.
 3. Evaluates the resolution condition against the current version.
 4. Compares version fingerprints with the last bot comment to detect changes.
 5. Posts a summary comment if: versions changed, it's Monday, or the workflow was triggered manually.

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -62,7 +62,7 @@ also-track: @angular/cli, @angular/compiler
 
 | Field         | Required | Description                                                       |
 | ------------- | -------- | ----------------------------------------------------------------- |
-| `package`     | Yes      | npm package name to check                                         |
+| `package`     | Yes      | [npm ↗](https://www.npmjs.com/) package name to check             |
 | `resolution`  | No       | Resolution condition (see below). Defaults to `manual`.           |
 | `description` | No       | Human-readable context for status reports                         |
 | `also-track`  | No       | Comma-separated list of additional packages to show in the report |

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -45,7 +45,7 @@ No app token needed — this workflow only reads the [npm ↗](https://www.npmjs
 
 ### Configuration
 
-The workflow uses a tracking epic issue. The `EPIC` constant in the workflow file must be set to the issue number during repository setup (see SETUP.md step 8).
+The workflow uses a tracking epic issue. The `EPIC` constant in the workflow file must be set to the issue number during repository setup.
 
 ### Issue Metadata Format
 

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use conventional commit message prefixes so they integrate cleanly with the [release-please ↗](https://github.com/googleapis/release-please) workflow.
+Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use [Conventional Commits ↗](https://www.conventionalcommits.org/) message prefixes so they integrate cleanly with the [release-please ↗](https://github.com/googleapis/release-please) workflow.
 
 ---
 

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use conventional commit message prefixes so they integrate cleanly with the release-please workflow.
+Automatically opens pull requests to update dependencies on a weekly schedule. PRs target the `dev` branch (not `main`) and use conventional commit message prefixes so they integrate cleanly with the [release-please ↗](https://github.com/googleapis/release-please) workflow.
 
 ---
 
@@ -18,7 +18,7 @@ Runs every **Monday**.
 
 ## Target Branch
 
-All Dependabot PRs target **`dev`**, not `main`. This ensures dependency updates go through the standard PR review and CI pipeline before reaching production.
+All [Dependabot ↗](https://github.com/dependabot) PRs target **`dev`**, not `main`. This ensures dependency updates go through the standard PR review and CI pipeline before reaching production.
 
 ---
 
@@ -64,15 +64,15 @@ Some dependencies are intentionally pinned without caret ranges (see `devDepende
 - **`typescript-eslint`** — pinned without `^` because patch releases have introduced breaking rule changes
 - **`@types/node`** — pinned to `~24.0.0` to match the Node 24 runtime
 
-Dependabot will still open PRs for these packages. Review them carefully and test before merging — the pinning is intentional and documented.
+[Dependabot ↗](https://github.com/dependabot) will still open PRs for these packages. Review them carefully and test before merging — the pinning is intentional and documented.
 
 ---
 
 ## CI Integration
 
-Dependabot PRs trigger the CI workflow like any other PR. However, the CI workflow handles Dependabot specially:
+[Dependabot ↗](https://github.com/dependabot) PRs trigger the CI workflow like any other PR. However, the CI workflow handles [Dependabot ↗](https://github.com/dependabot) specially:
 
-- **App token generation is skipped** — Dependabot cannot access repository secrets
-- **Submodule checkout is skipped** — Dependabot cannot access private submodules
+- **App token generation is skipped** — [Dependabot ↗](https://github.com/dependabot) cannot access repository secrets
+- **Submodule checkout is skipped** — [Dependabot ↗](https://github.com/dependabot) cannot access private submodules
 - **Falls back to `GITHUB_TOKEN`** — sufficient for read-only validation (audit, lint, typecheck, test)
 - **Badge commits are not generated** — badges only commit on push events, not PRs

--- a/docs/reference/workflows/dependabot.md
+++ b/docs/reference/workflows/dependabot.md
@@ -59,7 +59,7 @@ Updates action versions used in all workflow files (e.g., `actions/checkout@v4` 
 
 ## Interaction with Pinned Dependencies
 
-Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned` in `package.json`):
+Some dependencies are intentionally pinned without caret ranges (see `devDependenciesPinned`, a custom metadata field, in `package.json`):
 
 - **`typescript-eslint`** — pinned without `^` because patch releases have introduced breaking rule changes
 - **`@types/node`** — pinned to `~24.0.0` to match the Node 24 runtime

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -101,10 +101,10 @@ permissions:
 ### Steps
 
 1. **Checkout code** — Standard checkout (no full history needed).
-2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for GitHub Packages authentication.
+2. **Setup Node** — Configures [Node.js ↗](https://nodejs.org/) from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication.
 3. **Install dependencies** — `npm ci` for deterministic builds. `GITHUB_TOKEN` with `packages: write` handles publishing to the current repo's package, and `packages: read` (inherited) handles installing dependencies.
 4. **Build** — `npm run build` compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/`.
-5. **Publish** — `npm publish ./dist` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. Publishing from `dist/` directly means consumers resolve against ng-packagr's generated `package.json` with the correct APF entry points.
+5. **Publish** — `npm publish ./dist` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. Publishing from `dist/` directly means consumers resolve against [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr)'s generated `package.json` with the correct APF entry points.
 
 > **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.
 
@@ -114,9 +114,9 @@ permissions:
 
 ### Phase 1: Create/Update Release PR
 
-After a push to `main` that includes conventional commits (`feat:`, `fix:`), [release-please ↗](https://github.com/googleapis/release-please):
+After a push to `main` that includes [Conventional Commits ↗](https://www.conventionalcommits.org/) (`feat:`, `fix:`), [release-please ↗](https://github.com/googleapis/release-please):
 
-1. Reads all conventional commits since the last release tag.
+1. Reads all [Conventional Commits ↗](https://www.conventionalcommits.org/) since the last release tag.
 2. Determines the version bump:
     - `fix(…):` — **patch** (e.g., 1.0.0 to 1.0.1)
     - `feat(…):` — **minor** (e.g., 1.0.0 to 1.1.0)
@@ -135,7 +135,7 @@ When the Release PR is merged:
 
 1. Creates a GitHub Release with auto-generated release notes.
 2. Creates a git tag (e.g., `v0.1.1`).
-3. The `publish` job runs — builds and publishes the package to GitHub Packages.
+3. The `publish` job runs — builds and publishes the package to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 4. The push to `main` from the merge triggers CI (to update badges) and Sync (to merge main into dev).
 
 ---

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-The Release workflow automates versioning, changelog generation, GitHub Release creation, and npm publishing using Google's [release-please](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to GitHub Packages.
+The Release workflow automates versioning, changelog generation, GitHub Release creation, and [npm ↗](https://www.npmjs.com/) publishing using Google's [release-please ↗](https://github.com/googleapis/release-please). It eliminates the need to manually edit version numbers, write changelogs, or create release tags. When a release is created, the package is automatically published to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages).
 
 ---
 
@@ -103,10 +103,10 @@ permissions:
 1. **Checkout code** — Standard checkout (no full history needed).
 2. **Setup Node** — Configures Node from `.nvmrc` with `registry-url: "https://npm.pkg.github.com"` for GitHub Packages authentication.
 3. **Install dependencies** — `npm ci` for deterministic builds. `GITHUB_TOKEN` with `packages: write` handles publishing to the current repo's package, and `packages: read` (inherited) handles installing dependencies.
-4. **Build** — `npm run build` compiles TypeScript to `dist/`.
+4. **Build** — `npm run build` compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/`.
 5. **Publish** — `npm publish ./dist` with `NODE_AUTH_TOKEN` set to `GITHUB_TOKEN`. Publishing from `dist/` directly means consumers resolve against ng-packagr's generated `package.json` with the correct APF entry points.
 
-> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**GitHub Packages → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.
+> **Cross-repo `@teqbench` dependencies:** For packages that depend on other `@teqbench` packages, each dependency package must grant the consuming repository read access in its package settings (**[GitHub Packages ↗](https://github.com/orgs/teqbench/packages) → Manage access**). This applies to the entire transitive dependency tree, not just direct dependencies — same as CI.
 
 ---
 
@@ -114,7 +114,7 @@ permissions:
 
 ### Phase 1: Create/Update Release PR
 
-After a push to `main` that includes conventional commits (`feat:`, `fix:`), release-please:
+After a push to `main` that includes conventional commits (`feat:`, `fix:`), [release-please ↗](https://github.com/googleapis/release-please):
 
 1. Reads all conventional commits since the last release tag.
 2. Determines the version bump:
@@ -165,7 +165,7 @@ When the Release PR is merged:
 
 Key settings:
 
-- **`release-type: node`** — uses Node.js release strategy (reads `package.json`).
+- **`release-type: node`** — uses [Node.js ↗](https://nodejs.org/) release strategy (reads `package.json`).
 - **`extra-files`** — also bumps version in `package-lock.json` at two JSON paths.
 - **`include-component-in-tag: false`** — produces clean tags like `v0.1.1` instead of prefixed tags.
 - **`changelog-path`** — writes changelog to the repo root.
@@ -178,7 +178,7 @@ Key settings:
 }
 ```
 
-Tracks the current released version. Updated automatically by release-please. CI reads this file to generate the version badge.
+Tracks the current released version. Updated automatically by [release-please ↗](https://github.com/googleapis/release-please). CI reads this file to generate the version badge.
 
 ---
 

--- a/docs/reference/workflows/sync.md
+++ b/docs/reference/workflows/sync.md
@@ -7,7 +7,7 @@
 
 ## Purpose
 
-After release-please merges a Release PR to `main`, the `dev` branch falls behind — it's missing the version bump in `package.json`, the updated `CHANGELOG.md`, and the new `.release-please-manifest.json`. This workflow automatically merges `main` back into `dev` to keep the branches in sync.
+After [release-please ↗](https://github.com/googleapis/release-please) merges a Release PR to `main`, the `dev` branch falls behind — it's missing the version bump in `package.json`, the updated `CHANGELOG.md`, and the new `.release-please-manifest.json`. This workflow automatically merges `main` back into `dev` to keep the branches in sync.
 
 ---
 

--- a/docs/reference/workflows/sync.md
+++ b/docs/reference/workflows/sync.md
@@ -113,7 +113,7 @@ git push origin dev
 
 ## Interaction with Other Workflows
 
-| What Happens                 | Result                                                                                                                                          |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Sync pushes to `dev`         | CI on `dev` is **skipped** — the `[skip ci]` tag in the merge commit message suppresses the `push` trigger per the GitHub Actions specification |
-| Sync races with another push | Handled by `git pull --rebase` before pushing                                                                                                   |
+| What Happens                 | Result                                                                                                                                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Sync pushes to `dev`         | CI on `dev` is **skipped** — the `[skip ci]` tag in the merge commit message suppresses the `push` trigger per the [GitHub Actions ↗](https://docs.github.com/en/actions) specification |
+| Sync races with another push | Handled by `git pull --rebase` before pushing                                                                                                                                           |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import tseslint from 'typescript-eslint';
+import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
@@ -6,6 +7,7 @@ export default tseslint.config(
     },
     ...tseslint.configs.recommended,
     {
+        plugins: { tsdoc },
         languageOptions: {
             parserOptions: {
                 projectService: {
@@ -13,6 +15,9 @@ export default tseslint.config(
                 },
                 tsconfigRootDir: import.meta.dirname,
             },
+        },
+        rules: {
+            'tsdoc/syntax': 'warn',
         },
     }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "~24.12.0",
         "@vitest/coverage-v8": "^4.1.1",
         "eslint": "^9.39.2",
+        "eslint-plugin-tsdoc": "^0.5.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.3",
         "ng-packagr": "^21.2.1",
@@ -1098,6 +1099,50 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@microsoft/tsdoc-config": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+      "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "ajv": "~8.18.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.2"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
@@ -3594,6 +3639,211 @@
         }
       }
     },
+    "node_modules/eslint-plugin-tsdoc": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.5.2.tgz",
+      "integrity": "sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@microsoft/tsdoc-config": "0.18.1",
+        "@typescript-eslint/utils": "~8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-tsdoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -3867,6 +4117,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3944,6 +4204,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-escaper": {
@@ -4049,6 +4322,22 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -4174,6 +4463,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5105,6 +5401,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5275,6 +5578,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -5704,6 +6028,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "~24.12.0",
     "@vitest/coverage-v8": "^4.1.1",
     "eslint": "^9.39.2",
+    "eslint-plugin-tsdoc": "^0.5.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.3",
     "ng-packagr": "^21.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teqbench/tbx-models",
   "version": "1.0.0",
-  "description": "TypeScript domain model interfaces for the TeqBench application framework. Provides TbxBaseModel contracts consumed by all @teqbench packages.",
+  "description": "TypeScript domain model interfaces for the TeqBench application framework. Provides TbxModel contracts consumed by all @teqbench packages.",
   "type": "module",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "TypeScript domain model interfaces for the TeqBench application framework. Provides TbxModel contracts consumed by all @teqbench packages.",
   "type": "module",
+  "keywords": [
+    "typescript"
+  ],
   "license": "Apache-2.0",
   "engines": {
     "node": ">=24.0.0"

--- a/src/base-model.spec.ts
+++ b/src/base-model.spec.ts
@@ -1,8 +1,8 @@
-import type { TbxBaseModel } from './base-model';
+import type { TbxModel } from './base-model';
 
-describe('TbxBaseModel', () => {
+describe('TbxModel', () => {
     it('should accept an object with string id by default', () => {
-        const model: TbxBaseModel = {
+        const model: TbxModel = {
             id: 'abc-123',
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-06-15T12:30:00.000Z',
@@ -14,7 +14,7 @@ describe('TbxBaseModel', () => {
     });
 
     it('should accept a numeric id when parameterised with number', () => {
-        const model: TbxBaseModel<number> = {
+        const model: TbxModel<number> = {
             id: 42,
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-06-15T12:30:00.000Z',
@@ -24,7 +24,7 @@ describe('TbxBaseModel', () => {
     });
 
     it('should enforce readonly on all properties', () => {
-        const model: TbxBaseModel = {
+        const model: TbxModel = {
             id: 'readonly-test',
             createdAt: '2025-01-01T00:00:00.000Z',
             updatedAt: '2025-01-01T00:00:00.000Z',
@@ -36,7 +36,7 @@ describe('TbxBaseModel', () => {
     });
 
     it('should allow extension with additional properties', () => {
-        interface User extends TbxBaseModel {
+        interface User extends TbxModel {
             email: string;
         }
 

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -1,6 +1,7 @@
 /**
- * Base interface for all TeqBench domain models.
+ * Base interface for all TeqBench domain models
  *
+ * @remarks
  * Every persistable entity in the TeqBench framework extends this contract,
  * ensuring a consistent shape for identity and audit timestamps across all
  * `@teqbench` packages.
@@ -8,6 +9,12 @@
  * @typeParam TId - The type used for the model's unique identifier.
  *   Defaults to `string` (typically a UUID v4), but can be narrowed to
  *   `number`, a branded type, or any other identifier strategy.
+ *
+ * @usage
+ * Extend this interface for every domain entity that will be persisted.
+ * The generic parameter allows adapting the identifier type to the
+ * backing data store (e.g., `string` for UUIDs, `number` for
+ * auto-increment keys).
  *
  * @example
  * ```typescript
@@ -21,27 +28,44 @@
  *     label: string;
  * }
  * ```
+ *
+ * @category Models
+ * @category Foundational
+ * @displayName Base Model
+ * @order 1
+ * @since 1.0.0
+ *
+ * @public
  */
 export interface TbxModel<TId = string> {
     /**
-     * Unique identifier for the model instance.
+     * Unique identifier for the model instance
      *
+     * @remarks
      * The concrete type is determined by the `TId` generic parameter.
      * When omitted, `TId` defaults to `string`.
+     *
+     * @public
      */
     readonly id: TId;
 
     /**
-     * ISO-8601 timestamp indicating when the record was created.
+     * ISO-8601 timestamp indicating when the record was created
      *
+     * @remarks
      * Set once at creation time and never modified thereafter.
+     *
+     * @public
      */
     readonly createdAt: string;
 
     /**
-     * ISO-8601 timestamp indicating when the record was last updated.
+     * ISO-8601 timestamp indicating when the record was last updated
      *
+     * @remarks
      * Updated automatically whenever the record is persisted with changes.
+     *
+     * @public
      */
     readonly updatedAt: string;
 }

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -45,6 +45,8 @@ export interface TbxModel<TId = string> {
      * The concrete type is determined by the `TId` generic parameter.
      * When omitted, `TId` defaults to `string`.
      *
+     * @order 1
+     *
      * @public
      */
     readonly id: TId;
@@ -55,6 +57,8 @@ export interface TbxModel<TId = string> {
      * @remarks
      * Set once at creation time and never modified thereafter.
      *
+     * @order 2
+     *
      * @public
      */
     readonly createdAt: string;
@@ -64,6 +68,8 @@ export interface TbxModel<TId = string> {
      *
      * @remarks
      * Updated automatically whenever the record is persisted with changes.
+     *
+     * @order 3
      *
      * @public
      */

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -57,8 +57,6 @@ export interface TbxModel<TId = string> {
      * @remarks
      * Set once at creation time and never modified thereafter.
      *
-     * @see {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 Date and time format}
-     *
      * @order 2
      *
      * @public
@@ -70,8 +68,6 @@ export interface TbxModel<TId = string> {
      *
      * @remarks
      * Updated automatically whenever the record is persisted with changes.
-     *
-     * @see {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 Date and time format}
      *
      * @order 3
      *

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -12,17 +12,17 @@
  * @example
  * ```typescript
  * // Default string identifier
- * interface User extends TbxBaseModel {
+ * interface User extends TbxModel {
  *     email: string;
  * }
  *
  * // Numeric identifier
- * interface LegacyRecord extends TbxBaseModel<number> {
+ * interface LegacyRecord extends TbxModel<number> {
  *     label: string;
  * }
  * ```
  */
-export interface TbxBaseModel<TId = string> {
+export interface TbxModel<TId = string> {
     /**
      * Unique identifier for the model instance.
      *

--- a/src/base-model.ts
+++ b/src/base-model.ts
@@ -52,10 +52,12 @@ export interface TbxModel<TId = string> {
     readonly id: TId;
 
     /**
-     * ISO-8601 timestamp indicating when the record was created
+     * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601} timestamp indicating when the record was created
      *
      * @remarks
      * Set once at creation time and never modified thereafter.
+     *
+     * @see {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 Date and time format}
      *
      * @order 2
      *
@@ -64,10 +66,12 @@ export interface TbxModel<TId = string> {
     readonly createdAt: string;
 
     /**
-     * ISO-8601 timestamp indicating when the record was last updated
+     * {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601} timestamp indicating when the record was last updated
      *
      * @remarks
      * Updated automatically whenever the record is persisted with changes.
+     *
+     * @see {@link https://www.iso.org/iso-8601-date-and-time-format.html | ISO 8601 Date and time format}
      *
      * @order 3
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 /**
- * TypeScript domain model interfaces for the TeqBench application framework
+ * {@link https://www.typescriptlang.org/ | TypeScript} domain model interfaces for the TeqBench application framework
  *
  * @remarks
  * This package provides the foundational model contracts consumed by all
  * `@teqbench` packages. The primary export is {@link TbxModel}, a generic
  * interface defining identity and audit timestamp shape for every persistable
  * entity.
+ *
+ * @see {@link https://www.typescriptlang.org/ | TypeScript}
  *
  * @packageDocumentation
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export type { TbxBaseModel } from './base-model';
+export type { TbxModel } from './base-model';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,12 @@
+/**
+ * TypeScript domain model interfaces for the TeqBench application framework
+ *
+ * @remarks
+ * This package provides the foundational model contracts consumed by all
+ * `@teqbench` packages. The primary export is {@link TbxModel}, a generic
+ * interface defining identity and audit timestamp shape for every persistable
+ * entity.
+ *
+ * @packageDocumentation
+ */
 export type { TbxModel } from './base-model';

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "tagDefinitions": [
+    {
+      "tagName": "@category",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@since",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@related",
+      "syntaxKind": "block",
+      "allowMultiple": true
+    },
+    {
+      "tagName": "@usage",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@displayName",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    },
+    {
+      "tagName": "@order",
+      "syntaxKind": "block",
+      "allowMultiple": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add external hyperlinks (↗ icons) to every prose mention of an external technology across all markdown and TSDoc files
- Align CLAUDE.md with latest TeqBench conventions (TSDoc, External Linking, AI Friendliness sections)
- Add `v8 ignore next` pragma documentation, Tag Ordering, Reference Implementation, and Verification subsections
- Fix AI friendliness audit findings (duplicate `@see` tags, dangling file references, empty markdown sections, custom field documentation)
- Add ISO 8601 spec links to model TSDoc and README
- Add Feedback section to README with issue template links
- Update skills submodule to latest

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run test:coverage` passes
- [x] `npm run build` succeeds
- [x] `/external-link-verification` reports 0 findings
- [x] `/ai-friendliness-verification` reports 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)