### PR TITLE
docs(security): switch reporting channel from advisory URL to email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest version on `main` is the only supported version.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-To report a vulnerability, open a [GitHub Security Advisory ↗](https://github.com/teqbench/tbx-models/security/advisories/new) via the **Security** tab of this repository. This keeps the report private until a fix is available.
+To report a vulnerability, email [info@teqbench.dev](mailto:info@teqbench.dev) with the details. This keeps the report private until a fix is available.
 
 Include as much of the following as possible:
 


### PR DESCRIPTION
## Summary

- Switch SECURITY.md vulnerability reporting from GitHub Security Advisory URL to email (info@teqbench.dev)
- Private repo convention — GitHub Private vulnerability reporting requires GitHub Advanced Security
- Fix AI friendliness audit findings (duplicate @see tags, dangling file references, empty markdown sections, custom field docs)

## Test plan

- [x] CI passes
- [x] SECURITY.md reporting channel matches private repo convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)