### PR TITLE
chore(models): update license field in lockfile to AGPL-3.0-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@teqbench/tbx-models",
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
         "@types/node": "~24.12.0",
         "@vitest/coverage-v8": "^4.1.1",


### PR DESCRIPTION
## Summary
- Update `package-lock.json` license field from `Apache-2.0` to `AGPL-3.0-only` to match the root `package.json` license.

## Test plan
- [x] Verify `npm ci` installs cleanly with the updated lockfile.
- [x] Confirm CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)