### PR TITLE
chore(deps): add .claude/ to ESLint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import tsdoc from 'eslint-plugin-tsdoc';
 
 export default tseslint.config(
     {
-        ignores: ['coverage/', 'dist/', 'node_modules/'],
+        ignores: ['.claude/', 'coverage/', 'dist/', 'node_modules/'],
     },
     ...tseslint.configs.recommended,
     {


### PR DESCRIPTION
## Summary

- Add `.claude/` to ESLint ignores to prevent stale worktree files from breaking lint

Closes #32

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test:coverage` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)