### PR TITLE
feat(docs): overhaul README and adopt the per-package docs pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,73 @@
 
 ![Build Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-status.json) ![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-tests.json) ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-coverage.json) ![Version](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-version.json) ![Build Number](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4/raw/tbx-models-main-build-number.json)
 
-> [TypeScript ↗](https://www.typescriptlang.org/) domain model interfaces for the TeqBench application framework. Provides TbxDomainEntityModel contracts consumed by all @teqbench packages.
+> Foundational [TypeScript ↗](https://www.typescriptlang.org/) domain-model interfaces for the TeqBench framework — a single generic `TbxDomainEntityModel<TId>` contract establishing identity and audit-timestamp shape for every persistable entity consumed across all `@teqbench` packages.
+
+<details>
+<summary><strong>Table of contents</strong></summary>
+
+- [Overview](#overview)
+- [At a glance](#at-a-glance)
+- [When to use](#when-to-use)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Concepts](#concepts)
+- [API Reference](#api-reference)
+- [Accessibility](#accessibility)
+- [Compatibility](#compatibility)
+- [Versioning & releases](#versioning--releases)
+- [Contributing](#contributing)
+- [Security](#security)
+- [Feedback](#feedback)
+- [License](#license)
+
+</details>
+
+## Overview
+
+`@teqbench/tbx-models` defines the single foundational contract that every persistable domain entity in the TeqBench framework extends. It is intentionally small — one generic `interface TbxDomainEntityModel<TId = string>` with three properties (`id`, `createdAt`, `updatedAt`) and nothing else. The point isn't feature surface; the point is that every other `@teqbench` package that touches persisted data consumes this one contract, so every entity in a TeqBench-based application shares the same identity and audit-timestamp shape.
+
+The contract is a [TypeScript ↗](https://www.typescriptlang.org/) `interface`, not a class — the package ships zero runtime code. When compiled, consuming applications gain static type-checking against the contract with no bundle-size cost, no runtime dependencies, and no behavior that could drift between versions. The only thing that can change in this package is the shape of the contract itself, and that shape is intentionally conservative: the three properties are the minimum useful set for a persistable entity across any reasonable storage backend.
+
+### Why a single shared contract
+
+Without a shared contract, every package in the framework that modeled a persistable entity would define its own ad-hoc `id` / `createdAt` / `updatedAt` fields — usually with subtly different types (`string` vs `Date`, optional vs required, `_id` vs `id`, millisecond timestamps vs ISO strings, etc.). Cross-package composition would require an adapter layer for each boundary. Keeping this one contract in a single foundational package means every package modeling an entity agrees on exactly the same three fields, and cross-package code can assume them without conversion.
+
+### The generic `TId` parameter
+
+The identifier type is generic (`TbxDomainEntityModel<TId = string>`) so consumers can adapt to whatever identifier strategy their storage backend uses without forking the interface. Common choices:
+
+- **`string` (the default)** — typically a UUID v4 generated client- or server-side. Good for distributed systems where ID generation doesn't need to round-trip to the database.
+- **`number`** — for legacy databases with auto-increment integer keys or for packages migrating from an older data model.
+- **Branded types** — e.g. `string & { readonly __brand: 'UserId' }` — for compile-time separation of identifier spaces so you can't accidentally pass a `UserId` where an `OrderId` is expected.
+
+Because `TId` is generic, consumers retain full type-inference on `id` fields throughout their domain model without runtime cost.
+
+### Audit timestamps
+
+`createdAt` and `updatedAt` are typed as `string`, carrying [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) formatted datetimes. This is deliberate: ISO 8601 strings serialize transparently to JSON without the timezone-ambiguity issues of `Date` objects (which JSON.stringify converts to UTC ISO strings anyway, but then JSON.parse returns strings, breaking round-trips). Storing the wire representation as the canonical type avoids one layer of conversion code at every storage boundary.
+
+The fields are not optional. Every persistable entity in TeqBench has both — set once at creation time (`createdAt`) and whenever the record changes (`updatedAt`). Entities that don't yet have these fields populated are "pre-persisted" transient models and should use a different shape (e.g. `Omit<TbxDomainEntityModel, 'createdAt' | 'updatedAt'>` or a distinct input-shape interface).
+
+## At a glance
+
+- **Single foundational contract** — one generic interface, `TbxDomainEntityModel<TId>`, shared by every persistable entity across all `@teqbench` packages.
+- **Generic identifier type** — parameterized `TId` (defaults to `string`) so consumers can use UUIDs, auto-increment numbers, or branded types without forking the interface.
+- **ISO 8601 audit timestamps** — `createdAt` and `updatedAt` are [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) strings that serialize transparently to JSON without timezone ambiguity.
+- **Types-only, zero runtime** — compiled-away [TypeScript ↗](https://www.typescriptlang.org/) interfaces with no JavaScript at runtime, no bundle-size cost, no dependencies.
+- **Read-only identity** — `id` is declared `readonly` so consumers can't accidentally mutate identity after creation.
+- **Strict minimum** — exactly three required properties, intentionally conservative so the contract stays stable across releases.
+- **Framework-wide consistency** — every `@teqbench` package that models a persistable entity extends this same contract; no per-package drift.
+
+## When to use
+
+Extend `TbxDomainEntityModel` for any domain entity that your application persists and reads back by identity. Typical examples: users, orders, content records, session records, audit events.
+
+Do not use it for:
+
+- **Transient input shapes** — form state, API request bodies, client-side derived objects that never get persisted. Define those as their own interfaces; don't inherit from the entity contract just because they're in the domain.
+- **Value objects** — an address, a monetary amount, a date range. Value objects have no identity and aren't independently persisted.
+- **Non-TeqBench models** — if you're modeling data for an external API or library, use that library's own contracts; don't force this shape onto it.
 
 ## Installation
 
@@ -20,19 +86,64 @@ npm install @teqbench/tbx-models
 
 ## Usage
 
+### Default string identifier
+
 ```typescript
 import type { TbxDomainEntityModel } from '@teqbench/tbx-models';
 
-// Extend TbxDomainEntityModel for your domain entities
 interface User extends TbxDomainEntityModel {
     email: string;
+    displayName: string;
 }
 
-// Use a numeric identifier
+// TypeScript infers: { id: string, createdAt: string, updatedAt: string, email: string, displayName: string }
+```
+
+### Numeric identifier
+
+```typescript
+import type { TbxDomainEntityModel } from '@teqbench/tbx-models';
+
 interface LegacyRecord extends TbxDomainEntityModel<number> {
     label: string;
 }
 ```
+
+### Branded identifier type
+
+```typescript
+import type { TbxDomainEntityModel } from '@teqbench/tbx-models';
+
+type UserId = string & { readonly __brand: 'UserId' };
+
+interface User extends TbxDomainEntityModel<UserId> {
+    email: string;
+}
+
+// Now a plain string cannot be passed where a UserId is expected, at compile time.
+```
+
+### Pre-persisted (input) shape
+
+```typescript
+import type { TbxDomainEntityModel } from '@teqbench/tbx-models';
+
+interface User extends TbxDomainEntityModel {
+    email: string;
+}
+
+// Input shape for creating a new user — no id, no audit timestamps yet.
+type CreateUserInput = Omit<User, 'id' | 'createdAt' | 'updatedAt'>;
+```
+
+## Concepts
+
+- **Domain entity** — a persistable object in the application's problem domain that is identified by a stable `id` and tracked by audit timestamps.
+- **Identifier type (`TId`)** — the generic parameter of `TbxDomainEntityModel` that lets consumers choose the identifier strategy (`string` default, `number`, branded type, etc.).
+- **Audit timestamp** — the `createdAt` / `updatedAt` pair carrying [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) datetimes that record when the entity was created and last modified.
+- **ISO 8601** — the international standard for date and time representation (e.g. `2026-04-12T19:30:00Z`) used as the wire format for audit timestamps.
+- **Branded type** — a nominal-typing [TypeScript ↗](https://www.typescriptlang.org/) pattern (e.g. `string & { readonly __brand: 'UserId' }`) that prevents accidental mixing of identifiers from different domains at compile time.
+- **Persistable entity** — an object the application stores and reads back by `id` — contrasted with transient input shapes or value objects, which should not extend this contract.
 
 ## API Reference
 
@@ -40,11 +151,15 @@ interface LegacyRecord extends TbxDomainEntityModel<number> {
 
 Base interface for all TeqBench domain models. Every persistable entity extends this contract.
 
-| Property    | Type     | Description                                                                                          |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `id`        | `TId`    | Unique identifier (defaults to `string`)                                                             |
-| `createdAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of record creation    |
-| `updatedAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp of last record update |
+| Property    | Type     | Description                                                                                                                  |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | `TId`    | Unique identifier. Readonly — set once at creation and never reassigned. Defaults to `string` when `TId` is omitted.         |
+| `createdAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp indicating when the record was created.       |
+| `updatedAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp indicating when the record was last modified. |
+
+## Accessibility
+
+Not applicable — types-only package, no UI surface.
 
 ## Compatibility
 
@@ -52,6 +167,18 @@ Base interface for all TeqBench domain models. Every persistable entity extends 
 | ----------------------------------------------- | -------- |
 | [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
 | [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
+
+## Versioning & releases
+
+This package follows [Semantic Versioning ↗](https://semver.org/). Versions and changelog entries are produced automatically by [Release Please ↗](https://github.com/googleapis/release-please) from [Conventional Commits ↗](https://www.conventionalcommits.org/) on `main`. See [CHANGELOG.md](CHANGELOG.md) for the full release history.
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
 
 ## Feedback
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,3 @@
+# Accessibility
+
+Not applicable — types-only package, no UI surface.

--- a/docs/concepts.yml
+++ b/docs/concepts.yml
@@ -1,0 +1,13 @@
+# Glossary rendered in the README "Concepts" section. Term -> one-line definition.
+- term: Domain entity
+  definition: A persistable object in the application's problem domain that is identified by a stable id and tracked by audit timestamps.
+- term: Identifier type (TId)
+  definition: The generic parameter of TbxDomainEntityModel that lets consumers choose the identifier strategy — string (default), number, branded type, etc.
+- term: Audit timestamp
+  definition: The createdAt / updatedAt pair carrying ISO 8601 datetimes that record when the entity was created and last modified.
+- term: ISO 8601
+  definition: The international standard for date and time representation (e.g. 2026-04-12T19:30:00Z) used as the wire format for audit timestamps.
+- term: Branded type
+  definition: A nominal-typing TypeScript pattern that prevents accidental mixing of identifiers from different domains at compile time, typically by intersecting a primitive type with a unique tag.
+- term: Persistable entity
+  definition: An object the application stores and reads back by id — contrasted with transient input shapes or value objects, which should not extend this contract.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -1,0 +1,16 @@
+# Short, scannable feature bullets rendered in the README "At a glance" section.
+# Each entry: one short noun phrase, one-line explanation.
+- name: Single foundational contract
+  summary: One generic interface, TbxDomainEntityModel, shared by every persistable entity across all @teqbench packages.
+- name: Generic identifier type
+  summary: Parameterized TId (defaults to string) so consumers can use UUIDs, auto-increment numbers, or branded types without forking the interface.
+- name: ISO 8601 audit timestamps
+  summary: createdAt and updatedAt are ISO 8601 strings that serialize transparently to JSON without timezone ambiguity.
+- name: Types-only, zero runtime
+  summary: Compiled-away TypeScript interfaces — no JavaScript at runtime, no bundle-size cost, no dependencies.
+- name: Read-only identity
+  summary: The id property is declared readonly so consumers can't accidentally mutate identity after creation.
+- name: Strict minimum
+  summary: Exactly three required properties — intentionally conservative so the contract stays stable across releases.
+- name: Framework-wide consistency
+  summary: Every @teqbench package that models a persistable entity extends this same contract; no per-package drift.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,39 @@
+---
+tagline: Foundational [TypeScript ↗](https://www.typescriptlang.org/) domain-model interfaces for the TeqBench framework — a single generic `TbxDomainEntityModel<TId>` contract establishing identity and audit-timestamp shape for every persistable entity consumed across all `@teqbench` packages.
+---
+
+## Overview
+
+`@teqbench/tbx-models` defines the single foundational contract that every persistable domain entity in the TeqBench framework extends. It is intentionally small — one generic `interface TbxDomainEntityModel<TId = string>` with three properties (`id`, `createdAt`, `updatedAt`) and nothing else. The point isn't feature surface; the point is that every other `@teqbench` package that touches persisted data consumes this one contract, so every entity in a TeqBench-based application shares the same identity and audit-timestamp shape.
+
+The contract is a [TypeScript ↗](https://www.typescriptlang.org/) `interface`, not a class — the package ships zero runtime code. When compiled, consuming applications gain static type-checking against the contract with no bundle-size cost, no runtime dependencies, and no behavior that could drift between versions. The only thing that can change in this package is the shape of the contract itself, and that shape is intentionally conservative: the three properties are the minimum useful set for a persistable entity across any reasonable storage backend.
+
+### Why a single shared contract
+
+Without a shared contract, every package in the framework that modeled a persistable entity would define its own ad-hoc `id` / `createdAt` / `updatedAt` fields — usually with subtly different types (`string` vs `Date`, optional vs required, `_id` vs `id`, millisecond timestamps vs ISO strings, etc.). Cross-package composition would require an adapter layer for each boundary. Keeping this one contract in a single foundational package means every package modeling an entity agrees on exactly the same three fields, and cross-package code can assume them without conversion.
+
+### The generic `TId` parameter
+
+The identifier type is generic (`TbxDomainEntityModel<TId = string>`) so consumers can adapt to whatever identifier strategy their storage backend uses without forking the interface. Common choices:
+
+- **`string` (the default)** — typically a UUID v4 generated client- or server-side. Good for distributed systems where ID generation doesn't need to round-trip to the database.
+- **`number`** — for legacy databases with auto-increment integer keys or for packages migrating from an older data model.
+- **Branded types** — e.g. `string & { readonly __brand: 'UserId' }` — for compile-time separation of identifier spaces so you can't accidentally pass a `UserId` where an `OrderId` is expected.
+
+Because `TId` is generic, consumers retain full type-inference on `id` fields throughout their domain model without runtime cost.
+
+### Audit timestamps
+
+`createdAt` and `updatedAt` are typed as `string`, carrying [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) formatted datetimes. This is deliberate: ISO 8601 strings serialize transparently to JSON without the timezone-ambiguity issues of `Date` objects (which JSON.stringify converts to UTC ISO strings anyway, but then JSON.parse returns strings, breaking round-trips). Storing the wire representation as the canonical type avoids one layer of conversion code at every storage boundary.
+
+The fields are not optional. Every persistable entity in TeqBench has both — set once at creation time (`createdAt`) and whenever the record changes (`updatedAt`). Entities that don't yet have these fields populated are "pre-persisted" transient models and should use a different shape (e.g. `Omit<TbxDomainEntityModel, 'createdAt' | 'updatedAt'>` or a distinct input-shape interface).
+
+## When to use
+
+Extend `TbxDomainEntityModel` for any domain entity that your application persists and reads back by identity. Typical examples: users, orders, content records, session records, audit events.
+
+Do not use it for:
+
+- **Transient input shapes** — form state, API request bodies, client-side derived objects that never get persisted. Define those as their own interfaces; don't inherit from the entity contract just because they're in the domain.
+- **Value objects** — an address, a monetary amount, a date range. Value objects have no identity and aren't independently persisted.
+- **Non-TeqBench models** — if you're modeling data for an external API or library, use that library's own contracts; don't force this shape onto it.

--- a/ng-package.json
+++ b/ng-package.json
@@ -3,5 +3,12 @@
   "dest": "dist",
   "lib": {
     "entryFile": "src/index.ts"
-  }
+  },
+  "assets": [
+    {
+      "input": "docs",
+      "glob": "*.{md,yml}",
+      "output": "docs"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Brings \`@teqbench/tbx-models\` in line with the [tbx-mat-banners reference ↗](https://github.com/teqbench/tbx-mat-banners), scaled down for a foundational types-only package. Scaffolds the hand-written \`docs/\` manifests and rewrites the README against the reference template. Generated via the \`tbx-package-docs-author\` skill with user-reviewed drafts for the tagline, overview narrative, and when-to-use anti-patterns.

## Hand-written manifests (ship in the tarball)

- \`docs/overview.md\` — tagline frontmatter plus extended narrative: why a single shared contract, \`TId\` generic parameter design, audit timestamp semantics (ISO 8601 strings over Date objects), when-to-use with explicit anti-patterns.
- \`docs/features.yml\` — 7 "At a glance" bullets.
- \`docs/concepts.yml\` — 6 glossary entries (Domain entity, Identifier type, Audit timestamp, ISO 8601, Branded type, Persistable entity).
- \`docs/accessibility.md\` — single-line not-applicable note kept for structural consistency with the reference template.

## Not authored (intentionally)

- \`docs/related.yml\` — no peer siblings at this foundational layer.
- Storybook split — types-only package, no UI.
- \`.github/workflows/docs-deploy.yml\` — no user-facing Storybook to deploy.

## README.md

Rewritten against the tbx-mat-banners reference with the trimmed section set for a types-only foundational package:

- Adds Overview (with three narrative subsections), At a glance, When to use, Concepts, Accessibility, Versioning & releases, Contributing, and Security sections.
- Expands Usage from one example to four — default string identifier, numeric identifier, branded identifier type, and pre-persisted input shape.

## Publish infrastructure

- \`ng-package.json\` — ships \`docs/*.md\` and \`docs/*.yml\` in the published tarball via a new asset entry. The shared release workflow will write CI-generated \`api.json\`/\`compatibility.json\`/\`metadata.json\` into \`dist/docs/\` on publish.

## Test plan

- [x] \`npm run format:check\`, \`npm run typecheck\`, \`npm run lint\` all pass
- [x] \`npm test\` — 4 tests pass
- [x] \`npm run build\` succeeds; \`dist/docs/\` contains the four hand-written manifests
- [ ] After release publishes, verify tarball contents include all 7 docs files (4 hand-written + 3 CI-generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)