### PR TITLE
docs(security): use GitHub advisory URL for vulnerability reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The latest version on `main` is the only supported version.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-To report a vulnerability, email [info@teqbench.dev](mailto:info@teqbench.dev) with the details. This keeps the report private until a fix is available.
+To report a vulnerability, use [GitHub Private vulnerability reporting ↗](https://github.com/teqbench/tbx-models/security/advisories/new). This keeps the report private until a fix is available.
 
 Include as much of the following as possible:
 


### PR DESCRIPTION
## Summary

- Switch SECURITY.md from email reporting to [GitHub Private Vulnerability Reporting](https://github.com/teqbench/tbx-models/security/advisories/new) since the repo is public.

## Why

Per the SECURITY.md Reporting Channel convention in CLAUDE.md, public repos should use PVR (CVE assignment, draft advisories, coordinated disclosure) rather than email. The repo transitioned to public without updating SECURITY.md.

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [ ] Reviewer enables Private Vulnerability Reporting at **Settings → Security → Privately reporting a vulnerability** if not already enabled at the org level

Closes #52