### PR TITLE
chore(test): remove stale coverage exclusion

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,9 @@ export default defineConfig({
         globals: true,
         passWithNoTests: false,
         coverage: {
-            exclude: [
-                // Interface-only — no runtime code to cover
-                'src/base-model.ts',
-            ],
+            // No exclusions: every source file should contribute to coverage.
+            // Interface-only files compile to zero runtime code, so V8 has
+            // nothing to miss and they do not need to be excluded explicitly.
             thresholds: {
                 lines: 80,
                 functions: 80,


### PR DESCRIPTION
## Summary

- Remove the \`src/base-model.ts\` entry from \`vitest.config.ts\` coverage exclusions — the file hasn't existed since v3.0.0.
- Replace it with a comment explaining why no exclusions are needed (interface-only files contribute zero V8 coverage targets).

## Why

The interface was renamed through three generations: \`BaseModel\` → \`TbxBaseModel\` (v1.0.0) → \`TbxModel\` (v2.0.0) → \`TbxDomainEntityModel\` (v3.0.0), with the source moving to \`src/models/domain-entity.model.ts\`. The exclusion entry was never updated and now points at a file that doesn't exist — a no-op that misleads future maintainers.

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run typecheck\` passes
- [x] \`npm run test:coverage\` passes (4 tests, exit 0; coverage thresholds satisfied because interface-only files have no V8 targets)

Closes #53