### PR TITLE
build: restore parent exclude entries in tsconfig.build.json

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {},
-  "exclude": ["**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

- Re-declare \`node_modules\` and \`dist\` in \`tsconfig.build.json\`'s \`exclude\` array so they aren't lost when the child overrides the parent's \`exclude\`.

## Why

Per the TypeScript \`extends\` spec, array fields are replaced, not merged. The build config previously overrode the parent's \`[\"node_modules\", \"dist\"]\` with just \`[\"**/*.spec.ts\"]\`, dropping the parent excludes. Today this is harmless because \`include: [\"src\"]\` scopes compilation, but the defense-in-depth is gone — broadening \`include\` would silently pick up build artifacts.

## Test plan

- [x] \`npm run build\` succeeds (ng-packagr completes in 751ms)
- [x] \`npm run typecheck\` passes
- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` passes

Closes #54