### PR TITLE
docs(prettierignore): rewrite stale template comment for .claude/skills

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,9 +19,9 @@ node_modules/
 # Vercel
 .vercel/
 
-# The submodule files are owned by the skills repo, not the foundation template.
-# The foundation's Prettier shouldn't be reformatting files from another repository.
+# Symlinked shared skills (populated from the .shared-skills submodule) — files
+# are owned by the upstream skills repo and should not be reformatted here.
 .claude/skills
 
-# Vendored shared-skills submodule — owned by the shared-skills repo, not this repo.
+# Vendored .shared-skills submodule — owned by the shared-skills repo, not this repo.
 .shared-skills


### PR DESCRIPTION
## Summary

- Rewrite the comment block in \`.prettierignore\` covering \`.claude/skills\` to accurately describe this repo and the directory.

## Why

The previous comment called this repo "the foundation template" and called \`.claude/skills\` a submodule. Neither holds: this is \`@teqbench/tbx-models\` (a leaf package, not a template), and \`.claude/skills\` is a directory of symlinks populated from the \`.shared-skills\` submodule — not itself a submodule. Template wording that doesn't match the repo confuses future maintainers.

## Test plan

- [x] \`npm run format:check\` passes (Prettier config behavior is unchanged — only the comment changed)

Closes #55