### PR TITLE
chore(ci): add concurrency group to dep-compat-check workflow

### DIFF
--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -10,6 +10,10 @@ on:
     - cron: "0 12 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: dep-compat-check-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   check:
     uses: teqbench/.github/.github/workflows/dep-compat-check.yml@main


### PR DESCRIPTION
## Summary

- Add a per-workflow concurrency group to \`dep-compat-check.yml\` matching the convention used by \`ci.yml\`, \`release.yml\`, \`sync.yml\`, and \`claude.yml\`.

## Why

\`dep-compat-check.yml\` was the lone workflow without a \`concurrency:\` block. Concurrent runs are unlikely (daily cron + manual dispatch), so this is a convention/consistency fix — making concurrency behavior explicit and preventing potential cross-workflow cancellation.

## Test plan

- [x] \`npm run format:check\` passes
- [ ] On next scheduled run (or manual dispatch), confirm the workflow still executes successfully

Closes #56