### PR TITLE
fix(docs): address findings from post-3.2.0 code review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This package provides [TypeScript ↗](https://www.typescriptlang.org) domain mo
 - `src/` — Source code (all `.ts` files live here)
 - `src/index.ts` — Barrel file (public API exports)
 - `dist/` — Compiled output (git-ignored, only this directory is published)
-- `docs/` — Documentation (placeholder for package-specific guides)
+- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) consumed to build the README, plus `reference/workflows/*.md` describing each CI/CD pipeline. Published with the package via `ng-package.json` assets.
 - `.github/workflows/` — CI/CD pipelines (ci, release, sync, dep-compat-check, claude)
 - Dependency updates run centrally via [Renovate ↗](https://docs.renovatebot.com/) (org-level workflow + `renovate-config.js` in `teqbench/.github`); no per-repo config is required
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ This package follows [Semantic Versioning ↗](https://semver.org/). Versions an
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
+Contributions are welcome. See the [contributing guide ↗](https://github.com/teqbench/.github/blob/main/CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
+See the [security policy ↗](https://github.com/teqbench/.github/blob/main/SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
 
 ## Feedback
 

--- a/docs/reference/workflows/renovate.md
+++ b/docs/reference/workflows/renovate.md
@@ -60,6 +60,18 @@ Ungrouped packages (e.g., `@types/node`) get individual PRs.
 
 ---
 
+## SHA Digest Pinning
+
+[GitHub Actions ↗](https://docs.github.com/en/actions) references — including reusable workflow calls like `uses: teqbench/.github/.github/workflows/ci.yml@<sha>` — are pinned to full commit SHAs. The central `renovate-config.js` sets `pinDigests: true` on the `github-actions` rule, so [Renovate ↗](https://docs.renovatebot.com/) adds the SHA on first scan and keeps it current as the referenced tag moves.
+
+Pinning to a full SHA is a supply-chain hardening: a compromised tag cannot silently redirect the workflow to malicious code between scheduled Renovate runs. The `# <tag>` comment after the SHA is preserved by [Renovate ↗](https://docs.renovatebot.com/) for human readability. The format in every workflow file is:
+
+```yaml
+uses: teqbench/.github/.github/workflows/ci.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+```
+
+---
+
 ## Auto-Merge
 
 Internal `@teqbench/*` packages are configured with `automerge: true` and `automergeType: "pr"`. When CI passes, Renovate merges the PR automatically — no human review required for internal version bumps.


### PR DESCRIPTION
## Summary

Three documentation findings from a post-3.2.0 code review pass (one independently corroborated by another review session). One \`fix:\` commit (user-clickable 404s on the README) and two \`docs:\` commits. Release-please will classify this as a patch bump.

| Commit | Finding | Severity | Change |
| --- | --- | --- | --- |
| \`fix(docs): repair README links to community health files\` | F1 | High | Point README Contributing/Security sections at the org \`.github\` repo instead of non-existent relative paths |
| \`docs(renovate): document pinDigests behavior for GitHub Actions\` | F2 | Low | Add a \"SHA Digest Pinning\" section to \`renovate.md\` explaining the \`@<sha> # <tag>\` format that now shows up in every workflow file |
| \`docs(claude): correct docs/ description in Project Structure\` | F3 | Low | Describe \`docs/\` as the per-package docs pipeline inputs it actually contains, not a \"placeholder\" |

## Why

- **F1:** The 3.2.0 community-health adoption (#65) deleted \`CONTRIBUTING.md\` and \`SECURITY.md\` from this repo, but \`README.md\`'s relative links were never updated. Clicking them on github.com returns 404. These are among the most-clicked README links — fixing them is a real user-facing bug fix.
- **F2:** Every workflow file uses the SHA-pin pattern (e.g. \`teqbench/.github/.github/workflows/ci.yml@7de482d... # main\`), enforced by \`pinDigests: true\` in the central \`renovate-config.js\`. The doc described grouping, schedule, and auto-merge but left readers wondering who pinned these SHAs and what maintains them.
- **F3:** \`docs/\` is not a placeholder. It holds \`overview.md\`, \`concepts.yml\`, \`features.yml\`, \`accessibility.md\`, and \`reference/workflows/*.md\` — the inputs to the per-package docs pipeline added in 3.1.0, published with the package via \`ng-package.json\` assets.

## Test plan

- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` passes
- [x] \`npm run typecheck\` passes
- [x] \`npm run test:coverage\` passes (4 tests, exit 0)
- [x] \`npm run build\` succeeds (ng-packagr APF output produced)
- [ ] After merge, verify the rendered README \"Contributing\" and \"Security\" links open the org-level files on github.com

## Related

- Follow-up to the post-3.2.0 review of this repo.
- F1 is a pattern worth auditing in every other public \`tbx-*\` repo that adopted the community-health change — sibling repos likely have the same broken README links.