### PR TITLE
release: ship post-3.2.0 code review fixes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@main
+    uses: teqbench/.github/.github/workflows/ci.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@main
+    uses: teqbench/.github/.github/workflows/claude.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@main
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@main
+    uses: teqbench/.github/.github/workflows/release.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@main
+    uses: teqbench/.github/.github/workflows/sync.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This package provides [TypeScript ↗](https://www.typescriptlang.org) domain mo
 - `src/` — Source code (all `.ts` files live here)
 - `src/index.ts` — Barrel file (public API exports)
 - `dist/` — Compiled output (git-ignored, only this directory is published)
-- `docs/` — Documentation (placeholder for package-specific guides)
+- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) consumed to build the README, plus `reference/workflows/*.md` describing each CI/CD pipeline. Published with the package via `ng-package.json` assets.
 - `.github/workflows/` — CI/CD pipelines (ci, release, sync, dep-compat-check, claude)
 - Dependency updates run centrally via [Renovate ↗](https://docs.renovatebot.com/) (org-level workflow + `renovate-config.js` in `teqbench/.github`); no per-repo config is required
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ This package follows [Semantic Versioning ↗](https://semver.org/). Versions an
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
+Contributions are welcome. See the [contributing guide ↗](https://github.com/teqbench/.github/blob/main/CONTRIBUTING.md) for local setup, [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) authentication, branch conventions, commit format, and the PR workflow.
 
 ## Security
 
-See [SECURITY.md](SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
+See the [security policy ↗](https://github.com/teqbench/.github/blob/main/SECURITY.md) for the supported-version policy and how to report a vulnerability privately.
 
 ## Feedback
 

--- a/docs/reference/workflows/renovate.md
+++ b/docs/reference/workflows/renovate.md
@@ -60,6 +60,18 @@ Ungrouped packages (e.g., `@types/node`) get individual PRs.
 
 ---
 
+## SHA Digest Pinning
+
+[GitHub Actions ↗](https://docs.github.com/en/actions) references — including reusable workflow calls like `uses: teqbench/.github/.github/workflows/ci.yml@<sha>` — are pinned to full commit SHAs. The central `renovate-config.js` sets `pinDigests: true` on the `github-actions` rule, so [Renovate ↗](https://docs.renovatebot.com/) adds the SHA on first scan and keeps it current as the referenced tag moves.
+
+Pinning to a full SHA is a supply-chain hardening: a compromised tag cannot silently redirect the workflow to malicious code between scheduled Renovate runs. The `# <tag>` comment after the SHA is preserved by [Renovate ↗](https://docs.renovatebot.com/) for human readability. The format in every workflow file is:
+
+```yaml
+uses: teqbench/.github/.github/workflows/ci.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+```
+
+---
+
 ## Auto-Merge
 
 Internal `@teqbench/*` packages are configured with `automerge: true` and `automergeType: "pr"`. When CI passes, Renovate merges the PR automatically — no human review required for internal version bumps.


### PR DESCRIPTION
## Summary

Carry the contents of \`dev\` to \`main\` so [release-please ↗](https://github.com/googleapis/release-please) can cut a patch release with the post-3.2.0 code review fixes.

## What's being shipped

Six commits ahead of \`main\`:

| Commit | Type | Driver | Release-please classification |
| --- | --- | --- | --- |
| \`0e2cf62\` | \`fix(docs):\` | Repair README links to community health files (F1) | **patch bump** |
| \`9a69a24\` | \`docs(renovate):\` | Document \`pinDigests\` behavior (F2) | no bump |
| \`051550b\` | \`docs(claude):\` | Correct \`docs/\` description in Project Structure (F3) | no bump |
| \`208772f\` | \`chore(ci):\` | Pin \`teqbench/.github\` action to \`7de482d\` (Renovate #68) | no bump |
| \`e61dab0\` | merge | PR #70 merge | no bump |
| \`b12700b\` | merge | PR #68 merge | no bump |

The single \`fix(docs):\` commit is what triggers the release — release-please will open a version-bump PR for **3.2.1** on \`main\` after this merges.

## Why this specifically fixes something user-visible

F1 (the patch-bump driver) repaired broken relative links in \`README.md\` to \`CONTRIBUTING.md\` and \`SECURITY.md\`. Those files were removed in 3.2.0's community-health adoption (#65), leaving the README links pointing at 404s on github.com. The fix points them at the org-level source files in [\`teqbench/.github\` ↗](https://github.com/teqbench/.github).

## Merge base status

\`main\` is already fully contained in \`dev\` via the prior sync workflow. No conflicts to resolve; the merge of \`main\` into this release branch was a no-op.

## Release flow

1. ✅ Create release branch off \`dev\`
2. ✅ Merge \`main\` into release branch (no-op this time)
3. 🔲 Merge this PR to \`main\`
4. 🔲 release-please opens a version-bump PR on \`main\` (→ 3.2.1)
5. 🔲 Merge the release-please PR — publishes to [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) and cuts a GitHub Release
6. 🔲 Sync workflow auto-merges \`main\` back into \`dev\`

## Test plan

- [x] All PR #70 CI checks passed on \`dev\`
- [x] No new commits landed on \`dev\` since \`dev\` CI last ran green
- [ ] CI passes on this release PR