### PR TITLE
docs(claude): scope docs/ publishing claim to pipeline inputs only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This package provides [TypeScript ↗](https://www.typescriptlang.org) domain mo
 - `src/` — Source code (all `.ts` files live here)
 - `src/index.ts` — Barrel file (public API exports)
 - `dist/` — Compiled output (git-ignored, only this directory is published)
-- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) consumed to build the README, plus `reference/workflows/*.md` describing each CI/CD pipeline. Published with the package via `ng-package.json` assets.
+- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) used to build the README and published with the package via `ng-package.json` assets. Also contains `reference/workflows/` describing each CI/CD pipeline.
 - `.github/workflows/` — CI/CD pipelines (ci, release, sync, dep-compat-check, claude)
 - Dependency updates run centrally via [Renovate ↗](https://docs.renovatebot.com/) (org-level workflow + `renovate-config.js` in `teqbench/.github`); no per-repo config is required
 


### PR DESCRIPTION
## Summary

One-line wording change in CLAUDE.md:35 (the \`docs/\` bullet in the \"Project Structure\" section). Tightens the sentence so the "published with the package" claim is grammatically bound only to the four top-level files that actually ship, not to the \`reference/workflows/\` subdirectory that doesn't.

## The factual drift

The ng-packagr asset configuration at [\`ng-package.json:9-10\`](https://github.com/teqbench/tbx-models/blob/main/ng-package.json#L9-L10) is:

\`\`\`json
{
  "input": "docs",
  "glob": "*.{md,yml}",
  "output": "docs"
}
\`\`\`

The glob is non-recursive — \`*\` only matches files at the top level of \`docs/\`. Building the package and inspecting \`dist/docs/\` confirms this:

\`\`\`
$ npm run build
$ ls dist/docs/
accessibility.md  concepts.yml  features.yml  overview.md
\`\`\`

No \`reference/\` subdirectory. The \`reference/workflows/*.md\` files are **not** published with the package — they are repo-only.

## Prior wording (committed in #70)

> \`docs/\` — Per-package docs pipeline inputs (\`overview.md\`, \`concepts.yml\`, \`features.yml\`, \`accessibility.md\`) consumed to build the README, plus \`reference/workflows/*.md\` describing each CI/CD pipeline. Published with the package via \`ng-package.json\` assets.

The trailing "Published with the package..." sentence has no explicit antecedent. A careful reader parses it as applying to the entire bullet, including \`reference/workflows/*.md\` — which overstates what the tarball contains.

## New wording

> \`docs/\` — Per-package docs pipeline inputs (\`overview.md\`, \`concepts.yml\`, \`features.yml\`, \`accessibility.md\`) used to build the README **and published with the package via \`ng-package.json\` assets**. Also contains \`reference/workflows/\` describing each CI/CD pipeline.

The \`and\` coordinator binds \"published\" to \"inputs\" — the four files that actually ship. The \`reference/workflows/\` sentence stands alone with no publishing claim, correctly implying repo-only.

## What this is not

This is a wording fix against the source of truth (\`ng-package.json\`). It is not changing what ships — \`ng-package.json\` is untouched. Shipping \`reference/workflows/\` would be a separate discussion (arguably useful for consumers who want to read the pipeline docs offline; arguably noise because they're repo-meta not package-meta).

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`ls dist/docs/\` shows exactly \`accessibility.md concepts.yml features.yml overview.md\` — no \`reference/\` directory
- [x] \`npm run format:check\` passes
- [x] \`npm run lint\` passes
- [x] Re-read CLAUDE.md line 35: the noun phrase immediately before \"published\" is the inputs list, not \`reference/workflows/\`

## Closes

F7 from the cross-repo code review cycle — the focused-session revision in that thread had a grammatical regression (standalone "Published..." adjacent to \`reference/workflows/\`); this wording repairs it.