### PR TITLE
release: carry CLAUDE.md docs/ bullet fix to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This package provides [TypeScript ↗](https://www.typescriptlang.org) domain mo
 - `src/` — Source code (all `.ts` files live here)
 - `src/index.ts` — Barrel file (public API exports)
 - `dist/` — Compiled output (git-ignored, only this directory is published)
-- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) consumed to build the README, plus `reference/workflows/*.md` describing each CI/CD pipeline. Published with the package via `ng-package.json` assets.
+- `docs/` — Per-package docs pipeline inputs (`overview.md`, `concepts.yml`, `features.yml`, `accessibility.md`) used to build the README and published with the package via `ng-package.json` assets. Also contains `reference/workflows/` describing each CI/CD pipeline.
 - `.github/workflows/` — CI/CD pipelines (ci, release, sync, dep-compat-check, claude)
 - Dependency updates run centrally via [Renovate ↗](https://docs.renovatebot.com/) (org-level workflow + `renovate-config.js` in `teqbench/.github`); no per-repo config is required
 


### PR DESCRIPTION
## Summary

Carry PR #73's one-line \`docs(claude):\` wording fix from \`dev\` to \`main\`.

## What's being shipped

Two commits ahead of \`main\`:

| Commit | Type | Change |
| --- | --- | --- |
| \`ef66ea8\` | \`docs(claude):\` | Scope \`docs/\` publishing claim to pipeline inputs only |
| \`73ed8a2\` | merge | PR #73 merge |

## ⚠️ No version bump expected

The only substantive commit on \`dev\` since v3.2.1 is \`docs(claude):\`. Per [release-please's default changelog-types ↗](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#change-log-types) — only \`fix:\` and \`feat:\` trigger version bumps by default. \`docs:\`, \`chore:\`, \`refactor:\` do not.

**Consequence:** After this PR merges to \`main\`, release-please will **not** open a version-bump PR. The commit lands on \`main\` and the CLAUDE.md on \`main\` becomes accurate, but no new package version will be published and no GitHub Release will be cut. The sync workflow will still merge \`main\` back to \`dev\` (which is a no-op here since \`dev\` is the source).

This is the correct outcome for a pure documentation correction with no shipped-artifact impact — \`ng-package.json\` is untouched, so the tarball contents are unchanged from v3.2.1.

If you want to force a release anyway (e.g., to have this change reflected in the CHANGELOG), add an empty \`fix:\` commit on this release branch before merging, matching the pattern from PR #64. Otherwise, the next \`fix:\`/\`feat:\` commit landing on \`dev\` will carry this change along in its release.

## Merge base status

\`main\` is fully contained in \`dev\` via the prior sync workflow after v3.2.1 published. The \`git merge origin/main\` against this release branch was a no-op.

## Release flow

1. ✅ Create release branch off \`dev\`
2. ✅ Merge \`main\` into release branch (no-op)
3. 🔲 Merge this PR to \`main\`
4. ⏭️ release-please does **not** open a version-bump PR (no \`fix:\`/\`feat:\` commits)
5. ⏭️ No package publish, no GitHub Release
6. 🔲 Sync workflow merges \`main\` back into \`dev\` (no-op since \`dev\` already has both commits)

## Test plan

- [x] All PR #73 CI checks passed on \`dev\`
- [x] No new commits on \`dev\` since #73 merged
- [ ] CI passes on this release PR