### PR TITLE
fix(build): include CHANGELOG.md in published tarball

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -9,6 +9,11 @@
       "input": "docs",
       "glob": "*.{md,yml}",
       "output": "docs"
+    },
+    {
+      "input": ".",
+      "glob": "CHANGELOG.md",
+      "output": "."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` to the `assets` array in `ng-package.json` so [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) copies it into `dist/` during build, causing it to be included in the published tarball.
- Lets the TeqBench website consume the changelog from `node_modules` rather than fetching from GitHub.
- Uses a `fix:` Conventional Commit type so Release Please cuts a patch release on merge to `main`.

## Verification

`npm run build` followed by `npm pack --dry-run` from `dist/` now lists `CHANGELOG.md` alongside `README.md` and `LICENSE`:

```
npm notice 📦  @teqbench/tbx-models@3.2.1
npm notice Tarball Contents
npm notice 4.3kB CHANGELOG.md
npm notice 34.5kB LICENSE
npm notice 12.1kB README.md
npm notice 71B docs/accessibility.md
npm notice 1.2kB docs/concepts.yml
npm notice 1.2kB docs/features.yml
npm notice 4.6kB docs/overview.md
npm notice 97B fesm2022/teqbench-tbx-models.mjs
npm notice 229B fesm2022/teqbench-tbx-models.mjs.map
npm notice 1.4kB package.json
npm notice 2.1kB types/teqbench-tbx-models.d.ts
npm notice total files: 11
```

Previously 10 files (no `CHANGELOG.md`); now 11.

## Test plan

- [ ] Review diff to `ng-package.json`.
- [ ] Confirm CI passes (build, lint, typecheck, tests, format).
- [ ] After merge to `dev` and subsequent release to `main`, confirm the published tarball on [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) contains `CHANGELOG.md` at the package root.