### PR TITLE
release: include CHANGELOG.md in published tarball

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -9,6 +9,11 @@
       "input": "docs",
       "glob": "*.{md,yml}",
       "output": "docs"
+    },
+    {
+      "input": ".",
+      "glob": "CHANGELOG.md",
+      "output": "."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Carries PR #75 from `dev` to `main` so Release Please can cut a patch release.

- `fix(build): include CHANGELOG.md in published tarball` — adds `CHANGELOG.md` to the [ng-packagr ↗](https://github.com/ng-packagr/ng-packagr) `assets` array so it is copied into `dist/` during build and included in the published tarball.

## Test plan

- [ ] Confirm CI passes on this PR.
- [ ] After merge, confirm Release Please opens a `release-please--*` PR bumping the patch version and updating `CHANGELOG.md`.
- [ ] After the Release Please PR merges, confirm the published tarball on [GitHub Packages ↗](https://github.com/orgs/teqbench/packages) contains `CHANGELOG.md` at the package root.