### PR TITLE
release: markdown tables convention, dependabot cleanup, and table conversions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance for Claude Code when working in this repository.
+This file provides guidance for [Claude Code ↗](https://github.com/anthropics/claude-code) when working in this repository.
 
 ## Package Overview
 
@@ -235,6 +235,27 @@ All [TSDoc ↗](https://tsdoc.org) comments, inline code comments, and markdown 
 - Configuration snapshots in documentation must note they are examples that may not reflect the current state.
 - Custom `package.json` metadata fields (not defined by the [npm ↗](https://www.npmjs.com) spec) must be identified as custom where referenced.
 
+## Markdown Tables Convention
+
+Avoid `<table>` and pipe-syntax tables in markdown files (`README.md`, `CHANGELOG.md`, guides, etc.). Use a `<dl>`/`<dt>`/`<dd>` definition list instead.
+
+- **Why.** [GitHub ↗](https://github.com/) doesn't honor any column-width controls in rendered markdown — `<col>`, `width=` attributes, and CSS in `<style>` blocks are all stripped. Multi-column tables wrap unpredictably across viewport sizes and look inconsistent between repos. Definition lists give the same name → description shape with predictable single-column flow that renders the same everywhere [GitHub ↗](https://github.com/) previews markdown.
+
+- **Pattern.**
+
+    ```html
+    <dl>
+        <dt><a href="https://example.com">Item name ↗</a></dt>
+        <dd>One-line description of the item.</dd>
+        <dt>Next item</dt>
+        <dd>Its description.</dd>
+    </dl>
+    ```
+
+    See `.github/profile/README.md` for the canonical example used on the TeqBench organization profile page.
+
+- **When tables are still acceptable.** Only inside source code that emits HTML to a non-[GitHub ↗](https://github.com/) renderer ([Storybook ↗](https://storybook.js.org/) docs pages rendered via [MDX ↗](https://mdxjs.com/), the website's own `<tbx-markdown>` walker, etc.) — those have full control over column widths. Anything that lands in a `.md` file rendered by [GitHub ↗](https://github.com/) itself follows the `<dl>` rule.
+
 ## Commit Convention
 
 Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) strictly:
@@ -269,3 +290,5 @@ Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) stric
 - Never delete branches.
 - Never modify CI workflow files without explicit instruction.
 - Never modify `release-please-config.json`, `.release-please-manifest.json`, or `CHANGELOG.md`.
+- Never modify secrets, tokens, or files containing them. Secrets are defined at the organization level on [GitHub ↗](https://github.com/); repo-local code should reference them by name only and never read or rewrite their values.
+- Never commit content intended to be private, regardless of repository visibility. Treat every commit as if the repo could become public.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ Not applicable — types-only package, no UI surface.
 
 ## Compatibility
 
-<dl>
-    <dt><a href="https://www.typescriptlang.org/">TypeScript ↗</a></dt>
-    <dd>~5.9.0</dd>
-    <dt><a href="https://nodejs.org/">Node.js ↗</a></dt>
-    <dd>>=24.0.0</dd>
-</dl>
+<!-- Kept as a pipe table until teqbench/.github#22 lands; the centralized CI README version-check regex extracts versions from this exact shape. -->
+
+| Dependency                                      | Version  |
+| ----------------------------------------------- | -------- |
+| [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
+| [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
 
 ## Versioning & releases
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,14 @@ type CreateUserInput = Omit<User, 'id' | 'createdAt' | 'updatedAt'>;
 
 Base interface for all TeqBench domain models. Every persistable entity extends this contract.
 
-| Property    | Type     | Description                                                                                                                  |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `id`        | `TId`    | Unique identifier. Readonly — set once at creation and never reassigned. Defaults to `string` when `TId` is omitted.         |
-| `createdAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp indicating when the record was created.       |
-| `updatedAt` | `string` | [ISO 8601 ↗](https://www.iso.org/iso-8601-date-and-time-format.html) timestamp indicating when the record was last modified. |
+<dl>
+    <dt><code>id</code> (<code>TId</code>)</dt>
+    <dd>Unique identifier. Readonly — set once at creation and never reassigned. Defaults to <code>string</code> when <code>TId</code> is omitted.</dd>
+    <dt><code>createdAt</code> (<code>string</code>)</dt>
+    <dd><a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601 ↗</a> timestamp indicating when the record was created.</dd>
+    <dt><code>updatedAt</code> (<code>string</code>)</dt>
+    <dd><a href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601 ↗</a> timestamp indicating when the record was last modified.</dd>
+</dl>
 
 ## Accessibility
 
@@ -163,10 +166,12 @@ Not applicable — types-only package, no UI surface.
 
 ## Compatibility
 
-| Dependency                                      | Version  |
-| ----------------------------------------------- | -------- |
-| [TypeScript ↗](https://www.typescriptlang.org/) | ~5.9.0   |
-| [Node.js ↗](https://nodejs.org/)                | >=24.0.0 |
+<dl>
+    <dt><a href="https://www.typescriptlang.org/">TypeScript ↗</a></dt>
+    <dd>~5.9.0</dd>
+    <dt><a href="https://nodejs.org/">Node.js ↗</a></dt>
+    <dd>>=24.0.0</dd>
+</dl>
 
 ## Versioning & releases
 

--- a/docs/reference/workflows/ci.md
+++ b/docs/reference/workflows/ci.md
@@ -13,10 +13,12 @@ The CI workflow is the quality gate for the repository. It runs formatting check
 
 ## Triggers
 
-| Event          | Branches      | Behavior                        |
-| -------------- | ------------- | ------------------------------- |
-| `push`         | `main`, `dev` | Full pipeline + badge gist push |
-| `pull_request` | `main`, `dev` | Full pipeline, no badge updates |
+<dl>
+    <dt><code>push</code> on <code>main</code>, <code>dev</code></dt>
+    <dd>Full pipeline + badge gist push.</dd>
+    <dt><code>pull_request</code> on <code>main</code>, <code>dev</code></dt>
+    <dd>Full pipeline, no badge updates.</dd>
+</dl>
 
 ---
 
@@ -33,12 +35,16 @@ Per-branch isolation: CI on `main` and `dev` run independently. Runs on the same
 
 ## Secrets & Variables
 
-| Name              | Type     | Scope | Purpose                                      |
-| ----------------- | -------- | ----- | -------------------------------------------- |
-| `APP_ID`          | Secret   | Repo  | GitHub App ID for generating a bot token     |
-| `APP_PRIVATE_KEY` | Secret   | Repo  | GitHub App private key                       |
-| `GIST_TOKEN`      | Secret   | Org   | PAT with `gist` scope for pushing badge data |
-| `GIST_ID`         | Variable | Org   | ID of the shared public badge gist           |
+<dl>
+    <dt><code>APP_ID</code> (Secret, Repo)</dt>
+    <dd>GitHub App ID for generating a bot token.</dd>
+    <dt><code>APP_PRIVATE_KEY</code> (Secret, Repo)</dt>
+    <dd>GitHub App private key.</dd>
+    <dt><code>GIST_TOKEN</code> (Secret, Org)</dt>
+    <dd>PAT with <code>gist</code> scope for pushing badge data.</dd>
+    <dt><code>GIST_ID</code> (Variable, Org)</dt>
+    <dd>ID of the shared public badge gist.</dd>
+</dl>
 
 The app token is used for checkout with submodules. The gist token is used to push badge JSON data to the shared gist owned by `teqbench-shields-bot`.
 
@@ -169,13 +175,18 @@ Compiles [TypeScript ↗](https://www.typescriptlang.org/) to `dist/` using `tsc
 
 Five badges are pushed as JSON to a shared public [GitHub Gist ↗](https://gist.github.com/teqbench-shields-bot/a69600f4ed4ebed89ffb35d808e05eb4) using `schneegans/dynamic-badges-action@v1.7.0`. [Shields.io ↗](https://shields.io) reads the JSON and renders the badges dynamically. Only runs on **push events** (not PRs).
 
-| Badge        | Style         | Source                                            | Gist Filename                       |
-| ------------ | ------------- | ------------------------------------------------- | ----------------------------------- |
-| Coverage     | for-the-badge | `coverage-summary.json` (lines pct)               | `{repo}-{branch}-coverage.json`     |
-| Tests        | for-the-badge | `report.json` (passed/total counts)               | `{repo}-{branch}-tests.json`        |
-| Build Status | for-the-badge | `job.status` (success/failure)                    | `{repo}-{branch}-build-status.json` |
-| Build Number | for-the-badge | `github.run_number`                               | `{repo}-{branch}-build-number.json` |
-| Version      | for-the-badge | `.release-please-manifest.json` or `package.json` | `{repo}-{branch}-version.json`      |
+<dl>
+    <dt>Coverage</dt>
+    <dd>Style: <code>for-the-badge</code>. Source: <code>coverage-summary.json</code> (lines pct). Gist filename: <code>{repo}-{branch}-coverage.json</code>.</dd>
+    <dt>Tests</dt>
+    <dd>Style: <code>for-the-badge</code>. Source: <code>report.json</code> (passed/total counts). Gist filename: <code>{repo}-{branch}-tests.json</code>.</dd>
+    <dt>Build Status</dt>
+    <dd>Style: <code>for-the-badge</code>. Source: <code>job.status</code> (success/failure). Gist filename: <code>{repo}-{branch}-build-status.json</code>.</dd>
+    <dt>Build Number</dt>
+    <dd>Style: <code>for-the-badge</code>. Source: <code>github.run_number</code>. Gist filename: <code>{repo}-{branch}-build-number.json</code>.</dd>
+    <dt>Version</dt>
+    <dd>Style: <code>for-the-badge</code>. Source: <code>.release-please-manifest.json</code> or <code>package.json</code>. Gist filename: <code>{repo}-{branch}-version.json</code>.</dd>
+</dl>
 
 All badge steps run with `if: always()` so badges update even on failure. The `schneegans/dynamic-badges-action` creates gist files automatically if they don't exist — no manual gist setup is needed per repository.
 
@@ -183,10 +194,12 @@ All badge steps run with `if: always()` so badges update even on failure. The `s
 
 ## Environment Variables
 
-| Variable     | Value                          | Purpose                                               |
-| ------------ | ------------------------------ | ----------------------------------------------------- |
-| `GIST_OWNER` | `teqbench-shields-bot`         | GitHub account that owns the shared badge gist        |
-| `REPO_NAME`  | `github.event.repository.name` | Derived automatically — used to prefix gist filenames |
+<dl>
+    <dt><code>GIST_OWNER</code></dt>
+    <dd>Value: <code>teqbench-shields-bot</code>. GitHub account that owns the shared badge gist.</dd>
+    <dt><code>REPO_NAME</code></dt>
+    <dd>Value: <code>github.event.repository.name</code>. Derived automatically — used to prefix gist filenames.</dd>
+</dl>
 
 ---
 

--- a/docs/reference/workflows/claude.md
+++ b/docs/reference/workflows/claude.md
@@ -13,11 +13,14 @@ The [Claude Code ↗](https://github.com/anthropics/claude-code) workflow provid
 
 ## Triggers
 
-| Event                                   | Condition                       |
-| --------------------------------------- | ------------------------------- |
-| `issue_comment` (created)               | Comment body contains `@claude` |
-| `pull_request_review_comment` (created) | Comment body contains `@claude` |
-| `issues` (opened)                       | Issue body contains `@claude`   |
+<dl>
+    <dt><code>issue_comment</code> (created)</dt>
+    <dd>Comment body contains <code>@claude</code>.</dd>
+    <dt><code>pull_request_review_comment</code> (created)</dt>
+    <dd>Comment body contains <code>@claude</code>.</dd>
+    <dt><code>issues</code> (opened)</dt>
+    <dd>Issue body contains <code>@claude</code>.</dd>
+</dl>
 
 ---
 
@@ -50,11 +53,14 @@ jobs:
 
 ## Secrets Used
 
-| Secret              | Purpose                                                               |
-| ------------------- | --------------------------------------------------------------------- |
-| `APP_ID`            | GitHub App ID for generating a bot token                              |
-| `APP_PRIVATE_KEY`   | GitHub App private key                                                |
-| `ANTHROPIC_API_KEY` | Authenticates with the [Anthropic API ↗](https://docs.anthropic.com/) |
+<dl>
+    <dt><code>APP_ID</code></dt>
+    <dd>GitHub App ID for generating a bot token.</dd>
+    <dt><code>APP_PRIVATE_KEY</code></dt>
+    <dd>GitHub App private key.</dd>
+    <dt><code>ANTHROPIC_API_KEY</code></dt>
+    <dd>Authenticates with the <a href="https://docs.anthropic.com/">Anthropic API ↗</a>.</dd>
+</dl>
 
 The app token is used for checkout with submodules ([Claude Code ↗](https://github.com/anthropics/claude-code) skills) and for full repository access.
 
@@ -121,44 +127,71 @@ Claude's capabilities are explicitly restricted via `--allowedTools` to prevent 
 
 ### File Tools (Built-in)
 
-| Tool        | Purpose               |
-| ----------- | --------------------- |
-| `View`      | Read file contents    |
-| `Edit`      | Modify existing files |
-| `Write`     | Create new files      |
-| `GlobTool`  | Find files by pattern |
-| `GrepTool`  | Search file contents  |
-| `BatchTool` | Batch file operations |
+<dl>
+    <dt><code>View</code></dt>
+    <dd>Read file contents.</dd>
+    <dt><code>Edit</code></dt>
+    <dd>Modify existing files.</dd>
+    <dt><code>Write</code></dt>
+    <dd>Create new files.</dd>
+    <dt><code>GlobTool</code></dt>
+    <dd>Find files by pattern.</dd>
+    <dt><code>GrepTool</code></dt>
+    <dd>Search file contents.</dd>
+    <dt><code>BatchTool</code></dt>
+    <dd>Batch file operations.</dd>
+</dl>
 
 ### Git Commands (Via Bash Allowlist)
 
-| Allowed           | Purpose                  |
-| ----------------- | ------------------------ |
-| `git status`      | Check working tree state |
-| `git diff`        | View changes             |
-| `git log`         | Browse commit history    |
-| `git branch`      | List/create branches     |
-| `git show`        | Inspect commits          |
-| `git checkout`    | Switch branches          |
-| `git add`         | Stage changes            |
-| `git commit`      | Create commits           |
-| `git push origin` | Push to remote           |
+Allowed:
 
-| Explicitly Excluded       | Reason                                     |
-| ------------------------- | ------------------------------------------ |
-| `git push --force`        | Destructive — rewrites history             |
-| `git reset`               | Destructive — can lose commits             |
-| `git rebase`              | Can rewrite history                        |
-| `git branch -D`           | Destructive — deletes branches             |
-| Arbitrary `bash` commands | Security — prevents uncontrolled execution |
+<dl>
+    <dt><code>git status</code></dt>
+    <dd>Check working tree state.</dd>
+    <dt><code>git diff</code></dt>
+    <dd>View changes.</dd>
+    <dt><code>git log</code></dt>
+    <dd>Browse commit history.</dd>
+    <dt><code>git branch</code></dt>
+    <dd>List/create branches.</dd>
+    <dt><code>git show</code></dt>
+    <dd>Inspect commits.</dd>
+    <dt><code>git checkout</code></dt>
+    <dd>Switch branches.</dd>
+    <dt><code>git add</code></dt>
+    <dd>Stage changes.</dd>
+    <dt><code>git commit</code></dt>
+    <dd>Create commits.</dd>
+    <dt><code>git push origin</code></dt>
+    <dd>Push to remote.</dd>
+</dl>
+
+Explicitly excluded:
+
+<dl>
+    <dt><code>git push --force</code></dt>
+    <dd>Destructive — rewrites history.</dd>
+    <dt><code>git reset</code></dt>
+    <dd>Destructive — can lose commits.</dd>
+    <dt><code>git rebase</code></dt>
+    <dd>Can rewrite history.</dd>
+    <dt><code>git branch -D</code></dt>
+    <dd>Destructive — deletes branches.</dd>
+    <dt>Arbitrary <code>bash</code> commands</dt>
+    <dd>Security — prevents uncontrolled execution.</dd>
+</dl>
 
 ### npm Commands (Via Bash Allowlist)
 
-| Allowed   | Purpose                                       |
-| --------- | --------------------------------------------- |
-| `npm run` | Run project scripts (test, lint, build)       |
-| `npm ci`  | Install dependencies                          |
-| `npx`     | Run [Node.js ↗](https://nodejs.org/) binaries |
+<dl>
+    <dt><code>npm run</code></dt>
+    <dd>Run project scripts (test, lint, build).</dd>
+    <dt><code>npm ci</code></dt>
+    <dd>Install dependencies.</dd>
+    <dt><code>npx</code></dt>
+    <dd>Run <a href="https://nodejs.org/">Node.js ↗</a> binaries.</dd>
+</dl>
 
 ---
 

--- a/docs/reference/workflows/dep-compat-check.md
+++ b/docs/reference/workflows/dep-compat-check.md
@@ -13,10 +13,12 @@ Tracks pinned dependencies that are waiting for a new version — for example, w
 
 ## Triggers
 
-| Event               | Schedule           |
-| ------------------- | ------------------ |
-| `schedule`          | Daily at 12:00 UTC |
-| `workflow_dispatch` | Manual trigger     |
+<dl>
+    <dt><code>schedule</code></dt>
+    <dd>Daily at 12:00 UTC.</dd>
+    <dt><code>workflow_dispatch</code></dt>
+    <dd>Manual trigger.</dd>
+</dl>
 
 ---
 
@@ -33,9 +35,10 @@ Only needs write access to issues for posting status comments.
 
 ## Secrets Used
 
-| Secret         | Purpose                     |
-| -------------- | --------------------------- |
-| `GITHUB_TOKEN` | Default token for API calls |
+<dl>
+    <dt><code>GITHUB_TOKEN</code></dt>
+    <dd>Default token for API calls.</dd>
+</dl>
 
 No app token needed — this workflow only reads the [npm ↗](https://www.npmjs.com/) registry and writes issue comments.
 
@@ -60,20 +63,27 @@ also-track: @angular/cli, @angular/compiler
 -->
 ```
 
-| Field         | Required | Description                                                       |
-| ------------- | -------- | ----------------------------------------------------------------- |
-| `package`     | Yes      | [npm ↗](https://www.npmjs.com/) package name to check             |
-| `resolution`  | No       | Resolution condition (see below). Defaults to `manual`.           |
-| `description` | No       | Human-readable context for status reports                         |
-| `also-track`  | No       | Comma-separated list of additional packages to show in the report |
+<dl>
+    <dt><code>package</code> (required)</dt>
+    <dd><a href="https://www.npmjs.com/">npm ↗</a> package name to check.</dd>
+    <dt><code>resolution</code> (optional)</dt>
+    <dd>Resolution condition (see below). Defaults to <code>manual</code>.</dd>
+    <dt><code>description</code> (optional)</dt>
+    <dd>Human-readable context for status reports.</dd>
+    <dt><code>also-track</code> (optional)</dt>
+    <dd>Comma-separated list of additional packages to show in the report.</dd>
+</dl>
 
 ### Resolution Conditions
 
-| Condition               | Behavior                                                              |
-| ----------------------- | --------------------------------------------------------------------- |
-| `semver-gte:<version>`  | Resolved when latest version >= target. Status: Monitoring or Blocked |
-| `semver-major:<number>` | Resolved when latest major >= target. Status: Resolved or Blocked     |
-| `manual` (or omitted)   | Always shows as Action Needed — requires manual evaluation            |
+<dl>
+    <dt><code>semver-gte:&lt;version&gt;</code></dt>
+    <dd>Resolved when latest version >= target. Status: Monitoring or Blocked.</dd>
+    <dt><code>semver-major:&lt;number&gt;</code></dt>
+    <dd>Resolved when latest major >= target. Status: Resolved or Blocked.</dd>
+    <dt><code>manual</code> (or omitted)</dt>
+    <dd>Always shows as Action Needed — requires manual evaluation.</dd>
+</dl>
 
 ### Evaluation Flow
 
@@ -85,12 +95,16 @@ also-track: @angular/cli, @angular/compiler
 
 ### Status Labels
 
-| Label         | Meaning                                        |
-| ------------- | ---------------------------------------------- |
-| Resolved      | Resolution condition met — ready to integrate  |
-| Blocked       | Waiting for a version that meets the condition |
-| Action needed | Manual resolution — requires human evaluation  |
-| Monitoring    | Condition met but keeping an eye on it         |
+<dl>
+    <dt>Resolved</dt>
+    <dd>Resolution condition met — ready to integrate.</dd>
+    <dt>Blocked</dt>
+    <dd>Waiting for a version that meets the condition.</dd>
+    <dt>Action needed</dt>
+    <dd>Manual resolution — requires human evaluation.</dd>
+    <dt>Monitoring</dt>
+    <dd>Condition met but keeping an eye on it.</dd>
+</dl>
 
 ---
 

--- a/docs/reference/workflows/release.md
+++ b/docs/reference/workflows/release.md
@@ -13,9 +13,10 @@ The Release workflow automates versioning, changelog generation, GitHub Release 
 
 ## Triggers
 
-| Event  | Branches |
-| ------ | -------- |
-| `push` | `main`   |
+<dl>
+    <dt><code>push</code></dt>
+    <dd>On <code>main</code>.</dd>
+</dl>
 
 Runs on every push to `main`, including merges from release branches, badge commits (though these have no releasable commits), and Release PR merges.
 
@@ -34,10 +35,12 @@ Separate from CI and Sync to prevent cross-workflow cancellation.
 
 ## Secrets Used
 
-| Secret            | Purpose                                  |
-| ----------------- | ---------------------------------------- |
-| `APP_ID`          | GitHub App ID for generating a bot token |
-| `APP_PRIVATE_KEY` | GitHub App private key                   |
+<dl>
+    <dt><code>APP_ID</code></dt>
+    <dd>GitHub App ID for generating a bot token.</dd>
+    <dt><code>APP_PRIVATE_KEY</code></dt>
+    <dd>GitHub App private key.</dd>
+</dl>
 
 The app token is used instead of `GITHUB_TOKEN` so that Release PRs and release commits can trigger downstream workflows (CI, Sync). GitHub's security policy prevents `GITHUB_TOKEN` from triggering other workflows.
 
@@ -184,8 +187,11 @@ Tracks the current released version. Updated automatically by [release-please â†
 
 ## Interaction with Other Workflows
 
-| Event                            | Triggers                                                                                     |
-| -------------------------------- | -------------------------------------------------------------------------------------------- |
-| Release PR opened/updated        | CI runs as status check on the PR                                                            |
-| Release PR merged (push to main) | CI (badge update), Release (creates GitHub Release + publishes), Sync (merges main into dev) |
-| GitHub Release created           | No additional workflow triggers                                                              |
+<dl>
+    <dt>Release PR opened/updated</dt>
+    <dd>CI runs as status check on the PR.</dd>
+    <dt>Release PR merged (push to main)</dt>
+    <dd>CI (badge update), Release (creates GitHub Release + publishes), Sync (merges main into dev).</dd>
+    <dt>GitHub Release created</dt>
+    <dd>No additional workflow triggers.</dd>
+</dl>

--- a/docs/reference/workflows/renovate.md
+++ b/docs/reference/workflows/renovate.md
@@ -6,7 +6,7 @@
 
 ## Purpose
 
-Automatically opens pull requests to update dependencies. PRs target the `dev` branch (not `main`) and use [Conventional Commits ↗](https://www.conventionalcommits.org/) message prefixes so they integrate cleanly with the [release-please ↗](https://github.com/googleapis/release-please) workflow. [Renovate ↗](https://docs.renovatebot.com/) replaced [Dependabot ↗](https://github.com/dependabot) at the organisation level for richer grouping, scheduling, and auto-merge support.
+Automatically opens pull requests to update dependencies. PRs target the `dev` branch (not `main`) and use [Conventional Commits ↗](https://www.conventionalcommits.org/) message prefixes so they integrate cleanly with the [release-please ↗](https://github.com/googleapis/release-please) workflow.
 
 ---
 
@@ -95,7 +95,7 @@ The `package.json` in this repo also documents these intents in the custom `devD
 
 ## CI Integration
 
-Renovate PRs trigger the standard CI workflow like any other PR. Because Renovate runs as the `teqbench-automation[bot]` app (not the special `dependabot[bot]` actor), CI has full access to organisation secrets and submodules — there are no Renovate-specific carve-outs in the workflow.
+Renovate PRs trigger the standard CI workflow like any other PR. Because Renovate runs as the `teqbench-automation[bot]` GitHub App, CI has full access to organisation secrets and submodules — there are no Renovate-specific carve-outs in the workflow.
 
 ---
 

--- a/docs/reference/workflows/renovate.md
+++ b/docs/reference/workflows/renovate.md
@@ -36,10 +36,12 @@ All Renovate PRs target **`dev`** (`baseBranchPatterns: ["dev"]`). Updates flow 
 
 ## Commit Message Conventions
 
-| Ecosystem                | Commit prefix  | Labels               |
-| ------------------------ | -------------- | -------------------- |
-| `npm` packages           | `chore(deps):` | `dependencies`       |
-| `github-actions` updates | `chore(ci):`   | `dependencies`, `ci` |
+<dl>
+    <dt><code>npm</code> packages</dt>
+    <dd>Commit prefix: <code>chore(deps):</code>. Labels: <code>dependencies</code>.</dd>
+    <dt><code>github-actions</code> updates</dt>
+    <dd>Commit prefix: <code>chore(ci):</code>. Labels: <code>dependencies</code>, <code>ci</code>.</dd>
+</dl>
 
 `gitAuthor` is set to the `teqbench-automation[bot]` account so commits are correctly attributed.
 
@@ -49,12 +51,16 @@ All Renovate PRs target **`dev`** (`baseBranchPatterns: ["dev"]`). Updates flow 
 
 Related packages are grouped into a single PR to reduce noise:
 
-| Group               | Packages                                                                                                                               |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `teqbench packages` | All `@teqbench/*` packages — auto-merged                                                                                               |
-| `tooling`           | `prettier`, `husky`, `lint-staged`, `vitest`, `prettier-*`, `@prettier/*`, `@vitest/*`, `eslint-*`, `@eslint/*`, `typescript-eslint`   |
-| `typescript`        | `typescript`                                                                                                                           |
-| `github-actions`    | All [GitHub Actions ↗](https://docs.github.com/en/actions) action updates (uses the `chore(ci):` prefix and `dependencies, ci` labels) |
+<dl>
+    <dt><code>teqbench packages</code></dt>
+    <dd>All <code>@teqbench/*</code> packages — auto-merged.</dd>
+    <dt><code>tooling</code></dt>
+    <dd><code>prettier</code>, <code>husky</code>, <code>lint-staged</code>, <code>vitest</code>, <code>prettier-*</code>, <code>@prettier/*</code>, <code>@vitest/*</code>, <code>eslint-*</code>, <code>@eslint/*</code>, <code>typescript-eslint</code>.</dd>
+    <dt><code>typescript</code></dt>
+    <dd><code>typescript</code>.</dd>
+    <dt><code>github-actions</code></dt>
+    <dd>All <a href="https://docs.github.com/en/actions">GitHub Actions ↗</a> action updates (uses the <code>chore(ci):</code> prefix and <code>dependencies, ci</code> labels).</dd>
+</dl>
 
 Ungrouped packages (e.g., `@types/node`) get individual PRs.
 
@@ -84,10 +90,12 @@ All other packages require manual review and merge.
 
 Some packages are intentionally pinned below a major version. These are enforced in the central `renovate-config.js` via `allowedVersions`, not in this repo's `package.json`:
 
-| Package       | Restriction | Rationale                                                                                                                                              |
-| ------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `eslint`      | `< 10.0.0`  | ESLint majors are held until [angular-eslint ↗](https://github.com/angular-eslint/angular-eslint) supports them across the framework's package family. |
-| `@types/node` | `< 25.0.0`  | Pinned to the major matching the [Node.js ↗](https://nodejs.org/) runtime (currently 24). Re-evaluated on each Node LTS bump.                          |
+<dl>
+    <dt><code>eslint</code> (<code>&lt; 10.0.0</code>)</dt>
+    <dd>ESLint majors are held until <a href="https://github.com/angular-eslint/angular-eslint">angular-eslint ↗</a> supports them across the framework's package family.</dd>
+    <dt><code>@types/node</code> (<code>&lt; 25.0.0</code>)</dt>
+    <dd>Pinned to the major matching the <a href="https://nodejs.org/">Node.js ↗</a> runtime (currently 24). Re-evaluated on each Node LTS bump.</dd>
+</dl>
 
 The `package.json` in this repo also documents these intents in the custom `devDependenciesPinned` metadata field (see `package.json`).
 

--- a/docs/reference/workflows/sync.md
+++ b/docs/reference/workflows/sync.md
@@ -13,9 +13,10 @@ After [release-please ↗](https://github.com/googleapis/release-please) merges 
 
 ## Triggers
 
-| Event  | Branches |
-| ------ | -------- |
-| `push` | `main`   |
+<dl>
+    <dt><code>push</code></dt>
+    <dd>On <code>main</code>.</dd>
+</dl>
 
 Sync runs on **every push to `main`** — release merges, badge commits, and non-release merges alike. This ensures `dev` never silently falls behind `main`. If `dev` is already up to date, the merge is a no-op and the push has nothing to send.
 
@@ -34,10 +35,12 @@ Separate from CI and Release to prevent cross-workflow cancellation.
 
 ## Secrets Used
 
-| Secret            | Purpose                                  |
-| ----------------- | ---------------------------------------- |
-| `APP_ID`          | GitHub App ID for generating a bot token |
-| `APP_PRIVATE_KEY` | GitHub App private key                   |
+<dl>
+    <dt><code>APP_ID</code></dt>
+    <dd>GitHub App ID for generating a bot token.</dd>
+    <dt><code>APP_PRIVATE_KEY</code></dt>
+    <dd>GitHub App private key.</dd>
+</dl>
 
 The app token allows the Sync workflow to bypass the `dev` branch protection ruleset (which requires PRs and status checks). Without the bot token, the push to `dev` would be rejected.
 
@@ -113,7 +116,9 @@ git push origin dev
 
 ## Interaction with Other Workflows
 
-| What Happens                 | Result                                                                                                                                                                                  |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Sync pushes to `dev`         | CI on `dev` is **skipped** — the `[skip ci]` tag in the merge commit message suppresses the `push` trigger per the [GitHub Actions ↗](https://docs.github.com/en/actions) specification |
-| Sync races with another push | Handled by `git pull --rebase` before pushing                                                                                                                                           |
+<dl>
+    <dt>Sync pushes to <code>dev</code></dt>
+    <dd>CI on <code>dev</code> is <strong>skipped</strong> — the <code>[skip ci]</code> tag in the merge commit message suppresses the <code>push</code> trigger per the <a href="https://docs.github.com/en/actions">GitHub Actions ↗</a> specification.</dd>
+    <dt>Sync races with another push</dt>
+    <dd>Handled by <code>git pull --rebase</code> before pushing.</dd>
+</dl>


### PR DESCRIPTION
## Summary

Carries the dev branch to main. Merged dev work since v3.2.2:

- **CLAUDE.md** — added the Markdown Tables Convention (requires `<dl>`/`<dt>`/`<dd>` over pipe tables for predictable GitHub rendering), title-line `[Claude Code ↗]` link, and two new safety bullets in "What Claude Should NOT Do" (secrets/tokens; private content). Ports forward from the tbx-ngx-http `fix/package-updates` branch.
- **renovate.md** — dropped the two residual Dependabot prose mentions left over from the org-level Renovate migration.
- **README.md and 6 workflow docs** — converted every rendered pipe-syntax markdown table to `<dl>`/`<dt>`/`<dd>` definition lists. The Compatibility table in `README.md` is intentionally left as a pipe table with an inline comment pointing to teqbench/.github#22 — the centralized CI version-check regex requires that exact shape until that issue ships dual-format extraction.

## Source PR

#79 — merged into dev.

## Test plan

- [x] CI green on dev after #79 merged
- [ ] Release-please picks this up and proposes a release PR with the appropriate version bump (docs-only commits → patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)