### PR TITLE
fix(ci): pin reusable workflows to @v2.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
     secrets: inherit


### PR DESCRIPTION
Part of #32 (in teqbench/.github), Wave 1

## Summary

Pins every thin caller in this repo to `teqbench/.github` v2.6.0 — the first versioned release of the org-wide reusable workflows. Replaces the prior `@main` / `@<sha> # main` references.

## Why

Tag-based pins read as auditable diffs in PRs, are immutable, and let Renovate auto-PR future bumps. This lands as `fix:` so release-please cuts a patch release after the PR carries to main.

## Test plan

- [ ] CI passes against the new pinned reusable workflow
- [ ] Once merged via dev → main, release-please proposes a patch bump