### PR TITLE
release: pin reusable workflows to @v2.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/ci.yml@v2.6.0
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,5 +24,5 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
-    uses: teqbench/.github/.github/workflows/claude.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/claude.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/dep-compat-check.yml
+++ b/.github/workflows/dep-compat-check.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   check:
-    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/dep-compat-check.yml@v2.6.0
     with:
       epic-issue-number: 1
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   release:
-    uses: teqbench/.github/.github/workflows/release.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/release.yml@v2.6.0
     secrets: inherit

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,5 +13,5 @@ concurrency:
 
 jobs:
   sync:
-    uses: teqbench/.github/.github/workflows/sync.yml@7de482dbdfad13f3ca7ba3f9be3111d69881c56a # main
+    uses: teqbench/.github/.github/workflows/sync.yml@v2.6.0
     secrets: inherit


### PR DESCRIPTION
Carries the workflow-pin change from `dev` to `main`. Once merged, release-please will open a patch-bump release PR for this repo.

Part of #32 (in teqbench/.github), Wave 1

## Test plan

- [ ] After merge, release-please opens a patch-bump release PR
- [ ] Merging that release PR publishes the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)