### PR TITLE
fix(changelog): strip broken at-mention autolinks from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).9.3 ([90390e3](https://github.com/teqbench/tbx-models/commit/90390e3f6779d27456f9fc4c53b409f6efedd790)), closes [#28](https://github.com/teqbench/tbx-models/issues/28)
+* **ci:** pin reusable workflows to v2.9.3 ([90390e3](https://github.com/teqbench/tbx-models/commit/90390e3f6779d27456f9fc4c53b409f6efedd790)), closes [#28](https://github.com/teqbench/tbx-models/issues/28)
 
 ## [3.2.4](https://github.com/teqbench/tbx-models/compare/v3.2.3...v3.2.4) (2026-05-09)
 
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).6.0 ([6d45616](https://github.com/teqbench/tbx-models/commit/6d456165fffbdc77d7bc2fc4dadde72d5cba1bad))
+* **ci:** pin reusable workflows to v2.6.0 ([6d45616](https://github.com/teqbench/tbx-models/commit/6d456165fffbdc77d7bc2fc4dadde72d5cba1bad))
 
 ## [3.2.3](https://github.com/teqbench/tbx-models/compare/v3.2.2...v3.2.3) (2026-05-04)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,17 @@ Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) stric
 - `refactor(scope): ...` — Refactor
 - `chore(scope): ...` — Maintenance
 
+### No Bare At-Prefixed Tokens
+
+Do not write the at-symbol followed by a non-slashed identifier in commit subjects or bodies. The release-please changelog renderer ([conventional-changelog-conventionalcommits ↗](https://github.com/conventional-changelog/conventional-changelog) v6 `writerOpts.transform`) rewrites such tokens as broken GitHub user-mention links, splitting version strings into links to non-existent users.
+
+- Version refs: write `v2.9.3`, not preceded by the at-symbol.
+- Scope/org refs in prose: write `teqbench`, not preceded by the at-symbol.
+- TSDoc tag refs in prose: write `related`, `example`, `since`, `category`, `returns`, `link` — not preceded by the at-symbol.
+- Fully-qualified scoped package paths that contain a forward slash remain safe; the renderer short-circuits them.
+
+Markdown formatting does not escape this rewrite: backticks and code spans in commit messages do not protect.
+
 ## Branching & Workflow
 
 - `main` — Production. Only receives merges from `release/*`, `hotfix/*`, or `release-please--*` branches.


### PR DESCRIPTION
## Summary

- Strip broken GitHub user-mention autolinks injected by release-please's changelog renderer from CHANGELOG.md.
- Add a CLAUDE.md section codifying the rule that bare at-prefixed tokens must not appear in commit subjects or bodies, with safe-form guidance for scoped package paths.
- Advance the `.shared-skills` submodule pointer to latest `main` to pull in waves 0 and 1 changelog fixes.

## Root cause

release-please uses `conventional-changelog-conventionalcommits@^6.0.0`. Its `writerOpts.transform` callback rewrites bare at-prefixed identifiers in commit subjects as GitHub user-mention links. The match terminates at the first `.` or `/`, so a token like `v2.9.3` written with a leading at-symbol is rendered as a broken link to a non-existent `v2` user with `.9.3` left as bare text. The link wrapping is hardcoded; no release-please or preset configuration disables it.

## Wave 2 of org-wide remediation

| Wave | Repo | Status |
|---|---|---|
| canary | tbx-mat-banners | merged to dev, release deferred to wave 4 |
| 0 | teqbench.dev.misc-skills | released to main |
| 1 | teqbench.dev.shared-skills | released to main |
| **2** | **tbx-models, tbx-ngx-errors, tbx-ngx-http, tbx-mat-icons (this PR)** | **in progress** |
| 3 | tbx-mat-severity-theme | pending |
| 4 | tbx-mat-{notifications, banners, bottom-sheets, dialogs} | pending |
| 5 | teqbench.app.{website, liists.webapp, tradingtoolbox.webapp} | pending |
| 6 | teqbench.dev.templates.tbx-package | pending |

## Test plan

- [ ] Reviewer confirms diff: CHANGELOG.md unwraps, 1 CLAUDE.md addition, 1 `.shared-skills` pointer advance.
- [ ] Merge to `dev`; carry to `main` via `release/*`; release-please opens its PR.
- [ ] Reviewer confirms the new release-please section does NOT contain `[at-x](...)` autolinks.
- [ ] Merge release-please PR; new tag is the artifact the website ingests.