### PR TITLE
release: changelog at-mention autolink fix + .shared-skills bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).9.3 ([90390e3](https://github.com/teqbench/tbx-models/commit/90390e3f6779d27456f9fc4c53b409f6efedd790)), closes [#28](https://github.com/teqbench/tbx-models/issues/28)
+* **ci:** pin reusable workflows to v2.9.3 ([90390e3](https://github.com/teqbench/tbx-models/commit/90390e3f6779d27456f9fc4c53b409f6efedd790)), closes [#28](https://github.com/teqbench/tbx-models/issues/28)
 
 ## [3.2.4](https://github.com/teqbench/tbx-models/compare/v3.2.3...v3.2.4) (2026-05-09)
 
 
 ### Bug Fixes
 
-* **ci:** pin reusable workflows to [@v2](https://github.com/v2).6.0 ([6d45616](https://github.com/teqbench/tbx-models/commit/6d456165fffbdc77d7bc2fc4dadde72d5cba1bad))
+* **ci:** pin reusable workflows to v2.6.0 ([6d45616](https://github.com/teqbench/tbx-models/commit/6d456165fffbdc77d7bc2fc4dadde72d5cba1bad))
 
 ## [3.2.3](https://github.com/teqbench/tbx-models/compare/v3.2.2...v3.2.3) (2026-05-04)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,17 @@ Follow [**Conventional Commits** ↗](https://www.conventionalcommits.org) stric
 - `refactor(scope): ...` — Refactor
 - `chore(scope): ...` — Maintenance
 
+### No Bare At-Prefixed Tokens
+
+Do not write the at-symbol followed by a non-slashed identifier in commit subjects or bodies. The release-please changelog renderer ([conventional-changelog-conventionalcommits ↗](https://github.com/conventional-changelog/conventional-changelog) v6 `writerOpts.transform`) rewrites such tokens as broken GitHub user-mention links, splitting version strings into links to non-existent users.
+
+- Version refs: write `v2.9.3`, not preceded by the at-symbol.
+- Scope/org refs in prose: write `teqbench`, not preceded by the at-symbol.
+- TSDoc tag refs in prose: write `related`, `example`, `since`, `category`, `returns`, `link` — not preceded by the at-symbol.
+- Fully-qualified scoped package paths that contain a forward slash remain safe; the renderer short-circuits them.
+
+Markdown formatting does not escape this rewrite: backticks and code spans in commit messages do not protect.
+
 ## Branching & Workflow
 
 - `main` — Production. Only receives merges from `release/*`, `hotfix/*`, or `release-please--*` branches.


### PR DESCRIPTION
## Summary

Carry `dev` → `main` to publish wave 2 of the changelog autolink remediation.

## Includes

- fix(changelog): strip broken at-mention autolinks from history
- CLAUDE.md: codify no-bare-at-prefixed-tokens rule
- .shared-skills submodule advanced to wave 1's tagged main

## Post-merge

release-please will open a release PR on `main` with the next patch version. Verify its appended CHANGELOG section is free of `[at-x](...)` autolinks before merging the release-please PR.