### PR TITLE
chore(ci): bump teqbench/.github ci.yml to v3.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: teqbench/.github/.github/workflows/ci.yml@v2.9.3
+    uses: teqbench/.github/.github/workflows/ci.yml@v3.0.1
     with:
       gist-id: ${{ vars.GIST_ID }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Bumps the `teqbench/.github/.github/workflows/ci.yml` caller reference to `v3.0.1`. The new tag removes the GitFlow source-branch guard that was blocking Renovate PRs to `main` post-Phase-1b cutover.

Uses a `release/*` head so the pre-existing guard in the consumer's pinned ci.yml version passes during this PR's own CI run.

## Test plan

- [ ] CI green (guard passes for `release/*` head)